### PR TITLE
Remove tools from agent initialization

### DIFF
--- a/services/bella-chat-service/app/agents/base_agent.py
+++ b/services/bella-chat-service/app/agents/base_agent.py
@@ -18,44 +18,26 @@ if TYPE_CHECKING:
 class BaseAgent:
     """Base class for chat agents."""
 
-    def __init__(self, model: "BaseChatModel", tools: list | None = None):
+    def __init__(self, model: "BaseChatModel"):
         """Initialize the simple chat agent.
 
         Args:
             model (BaseChatModel): The chat model to be used by the agent.
-            tools (list, optional): List of tools to be added to the agent. Defaults to None.
         """
         self.model: BaseChatModel = model
         self.graph: StateGraph = None
         self.chain: CompiledStateGraph = None
-        self.tools = tools or []
         self._memory = MemorySaver()
         self._build_agent()
 
     def _build_agent(self):
         """Build the agent."""
-        if self.tools:
-            self._add_tools(self.tools)
-            self._build_graph_with_tools()
-        else:
-            self._build_graph_without_tools()
+        self._build_graph()
         self._compile()
 
-    def _build_graph_with_tools(self):
-        """Build the state graph for the agent with tools."""
+    def _build_graph(self):
+        """Build the state graph for the agent."""
         raise NotImplementedError("This method should be implemented by subclasses.")
-
-    def _build_graph_without_tools(self):
-        """Build the state graph for the agent without tools."""
-        raise NotImplementedError("This method should be implemented by subclasses.")
-
-    def _add_tools(self, tools: list):
-        """Add tools to the agent.
-
-        Args:
-            tools (list): List of tools to add. Python functions to be added as tools.
-        """
-        self.model = self.model.bind_tools(tools)
 
     def _compile(self):
         """Compile the agent's model.

--- a/services/bella-chat-service/app/agents/rag_agent/agent.py
+++ b/services/bella-chat-service/app/agents/rag_agent/agent.py
@@ -16,10 +16,6 @@ from langgraph.graph import (
     START,
     StateGraph,
 )
-from langgraph.prebuilt import (
-    ToolNode,
-    tools_condition,
-)
 
 from app.agents.base_agent import BaseAgent
 from app.agents.prompts import ABOUT_BELLA_SYSTEM_PROMPT
@@ -46,14 +42,13 @@ class RAGAgent(BaseAgent):
         chain: The chain associated with the agent. Compiled graph.
     """
 
-    def __init__(self, model: "BaseChatModel", tools: list | None = None):
+    def __init__(self, model: "BaseChatModel"):
         """Initialize the simple chat agent.
 
         Args:
             model (BaseChatModel): The chat model to be used by the agent.
-            tools (list, optional): List of tools to be added to the agent. Defaults to None.
         """
-        super().__init__(model=model, tools=tools)
+        super().__init__(model=model)
         self.vector_store = get_app_vector_store()
         self._logger = GetAppLogger().get_logger()
 
@@ -108,29 +103,8 @@ class RAGAgent(BaseAgent):
 
         return {"messages": [await self.model.ainvoke(messages)]}
 
-    def _build_graph_with_tools(self):
-        """Build the state graph for the agent with tools."""
-        # Create the state graph
-        self.graph = StateGraph(State)
-
-        # Add the nodes
-        self.graph.add_node("find_relevant_contexts", self._find_relevant_contexts)
-        self.graph.add_node("generate_response", self._generate_response)
-        self.graph.add_node("tools", ToolNode(self.tools))
-
-        # Add edges
-        self.graph.add_edge(START, "find_relevant_contexts")
-        self.graph.add_edge("find_relevant_contexts", "generate_response")
-        self.graph.add_conditional_edges(
-            "generate_response",
-            # When the LLM response is tool calling, this condition will be true
-            tools_condition,
-        )
-        # Loop back to tools node for multiple tool calls
-        self.graph.add_edge("tools", "generate_response")
-
-    def _build_graph_without_tools(self):
-        """Build the state graph for the agent without tools."""
+    def _build_graph(self):
+        """Build the state graph for the agent."""
         # Create the state graph
         self.graph = StateGraph(State)
 

--- a/services/bella-chat-service/app/agents/simple_chat_agent/agent.py
+++ b/services/bella-chat-service/app/agents/simple_chat_agent/agent.py
@@ -9,10 +9,6 @@ from langgraph.graph import (
     START,
     StateGraph,
 )
-from langgraph.prebuilt import (
-    ToolNode,
-    tools_condition,
-)
 
 from app.agents.base_agent import BaseAgent
 from app.agents.prompts import ABOUT_BELLA_SYSTEM_PROMPT
@@ -32,14 +28,13 @@ class SimpleChatAgent(BaseAgent):
         chain: The chain associated with the agent. Compiled graph.
     """
 
-    def __init__(self, model: "BaseChatModel", tools: list | None = None):
+    def __init__(self, model: "BaseChatModel"):
         """Initialize the simple chat agent.
 
         Args:
             model (BaseChatModel): The chat model to be used by the agent.
-            tools (list, optional): List of tools to be added to the agent. Defaults to None.
         """
-        super().__init__(model=model, tools=tools)
+        super().__init__(model=model)
 
     async def _generate_response(self, state: State) -> dict:
         """Generate a response based on user input.
@@ -63,27 +58,8 @@ class SimpleChatAgent(BaseAgent):
 
         return {"messages": [await self.model.ainvoke(messages)]}
 
-    def _build_graph_with_tools(self):
-        """Build the state graph for the agent with tools."""
-        # Create the state graph
-        self.graph = StateGraph(State)
-
-        # Add the nodes
-        self.graph.add_node("generate_response", self._generate_response)
-        self.graph.add_node("tools", ToolNode(self.tools))
-
-        # Add edges
-        self.graph.add_edge(START, "generate_response")
-        self.graph.add_conditional_edges(
-            "generate_response",
-            # When the LLM response is tool calling, this condition will be true
-            tools_condition,
-        )
-        # Loop back to tools node for multiple tool calls
-        self.graph.add_edge("tools", "generate_response")
-
-    def _build_graph_without_tools(self):
-        """Build the state graph for the agent without tools."""
+    def _build_graph(self):
+        """Build the state graph for the agent."""
         # Create the state graph
         self.graph = StateGraph(State)
 


### PR DESCRIPTION
# Remove tools from agent initialization

- Having tools in agent could lead to tighter coupling and poor type hinting so removed tool calling from agent initialization.
- Tools should be added in the agents separately. The dependency injection can still be achieved by creating reusable tools modules and using across agents.