### PR TITLE
Refactor services to use Docker entrypoint scripts for database initialization

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -12,6 +12,7 @@ EMS_DEBUG=False
 # Database Configs
 EMS_STORAGE_TYPE="postgresql"
 EMS_DATABASE_URL=postgresql+asyncpg://ems_user:<password>@host.docker.internal:5432/expense_manager
+EMS_PG_DB_HOST=host.docker.internal
 EMS_PG_DB_USER=ems_user
 EMS_PG_DB_PASSWORD=<password>
 EMS_PG_DB_NAME=expense_manager

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -37,6 +37,7 @@ services:
       # Database configurations
       - STORAGE_TYPE=${EMS_STORAGE_TYPE}
       - DATABASE_URL=${EMS_DATABASE_URL}
+      - PG_DB_HOST=${EMS_PG_DB_HOST}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/developer/launch-apps.md
+++ b/docs/developer/launch-apps.md
@@ -57,6 +57,11 @@ ChatBot.
    docker-compose up -d
    ```
 
+   **Note:** The service uses an `entrypoint.sh` script that:
+   - Waits for PostgreSQL to be ready (60s timeout)
+   - Runs Alembic database migrations automatically
+   - Starts the FastAPI application
+
 ### Bella ChatBot Application
 
 1. Bella Chat Bot is not ready for containerization yet. To launch the Bella ChatBot service, navigate to the

--- a/mcps/ems-mcp-server/Dockerfile
+++ b/mcps/ems-mcp-server/Dockerfile
@@ -32,7 +32,10 @@ ENV PATH="/app/.venv/bin:$PATH" \
 COPY --from=builder /app/.venv ./.venv
 
 COPY app ./app
+COPY entrypoint.sh ./entrypoint.sh
+
+RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 8001
 
-CMD ["python", "app/main.py"]
+CMD ["/app/entrypoint.sh"]

--- a/mcps/ems-mcp-server/entrypoint.sh
+++ b/mcps/ems-mcp-server/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Starting EMS MCP Server..."
+
+# Start the application
+echo "Starting FastMCP application..."
+exec python app/main.py

--- a/services/bella-chat-service/Dockerfile
+++ b/services/bella-chat-service/Dockerfile
@@ -30,11 +30,17 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
+# Install postgresql-client for pg_isready
+RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/.venv ./.venv
 
 # optional
 COPY app ./app
+COPY entrypoint.sh ./entrypoint.sh
+
+RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 5000
 
-CMD ["python", "app/main.py"]
+CMD ["/app/entrypoint.sh"]

--- a/services/bella-chat-service/app/dependencies/agents.py
+++ b/services/bella-chat-service/app/dependencies/agents.py
@@ -48,7 +48,7 @@ async def create_orchestrator_agent():
     llm_client = get_app_synthesis_llm_client()
     rag_agent = get_rag_agent()
 
-    _logger.info(f"Connecting LangGraph checkpointer to: {settings.langgraph_pg_db_dsn[:50]}...")
+    _logger.info("Connecting LangGraph Postgres checkpointer...")
     async with AsyncPostgresSaver.from_conn_string(settings.langgraph_pg_db_dsn) as checkpointer:
         await checkpointer.setup()  # Idempotent — creates tables on first run
         _logger.info("LangGraph Postgres checkpointer initialised.")

--- a/services/bella-chat-service/app/main.py
+++ b/services/bella-chat-service/app/main.py
@@ -59,6 +59,8 @@ async def lifespan(app: FastAPI):
     # Set application start time
     app.state.start_time = datetime.now()
 
+    # Initialize orchestrator agent with async resources (Postgres checkpointer, MCP client)
+    # These must remain in lifespan as they are async context managers requiring proper cleanup
     async with create_orchestrator_agent() as orchestrator_agent:
         app.state.orchestrator_agent = orchestrator_agent
         yield

--- a/services/bella-chat-service/entrypoint.sh
+++ b/services/bella-chat-service/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+echo "Starting Bella Chat Service..."
+
+# Wait for LangGraph PostgreSQL checkpointer to be ready
+echo "Waiting for LangGraph PostgreSQL checkpointer at $LANGGRAPH_PG_DB_HOST:5432..."
+timeout=60
+elapsed=0
+until pg_isready -h "$LANGGRAPH_PG_DB_HOST" -p 5432; do
+  if [ $elapsed -ge $timeout ]; then
+    echo "Timeout: PostgreSQL did not become ready within ${timeout}s"
+    exit 1
+  fi
+  echo "PostgreSQL not ready yet, waiting... (${elapsed}/${timeout}s)"
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+echo "LangGraph PostgreSQL checkpointer is ready!"
+
+# Start the application
+echo "Starting FastAPI application..."
+exec python app/main.py

--- a/services/expense-manager-service/.env.sample
+++ b/services/expense-manager-service/.env.sample
@@ -11,6 +11,7 @@ ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
 # Database Settings
 STORAGE_TYPE = "postgresql"  # Options: "inmemory", "sqlite", "postgresql"
 DATABASE_URL=postgresql+asyncpg://ems_user:<password>@host.docker.internal:5432/expense_manager
+PG_DB_HOST = "host.docker.internal"
 PG_DB_USER = "ems_user"
 PG_DB_PASSWORD = "<password>"
 PG_DB_NAME = "expense_manager"

--- a/services/expense-manager-service/Dockerfile
+++ b/services/expense-manager-service/Dockerfile
@@ -29,10 +29,16 @@ ENV PATH="/app/.venv/bin:$PATH" \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 
+# Install postgresql-client for pg_isready
+RUN apt-get update && apt-get install -y postgresql-client && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/.venv ./.venv
 
 COPY app ./app
+COPY entrypoint.sh ./entrypoint.sh
+
+RUN chmod +x /app/entrypoint.sh
 
 EXPOSE 8000
 
-CMD ["python", "app/main.py"]
+CMD ["/app/entrypoint.sh"]

--- a/services/expense-manager-service/README.md
+++ b/services/expense-manager-service/README.md
@@ -51,7 +51,7 @@ expense-manager-service/
 │   │       ├── alembic/                                     # Alembic migrations
 │   │       ├── alembic.ini                                  # Alembic config
 │   │       ├── models/                                      # SQLAlchemy ORM models (account, period, spending_entry)
-│   │       ├── database.py                                  # Engine, session factory, Base, init_db/drop_db
+│   │       ├── database.py                                  # Engine, session factory, Base, init_db/drop_db (for tests)
 │   │       └── *.py                                         # Postgres repository implementations
 │   ├── routers/                                             # Presentation/API layer
 │   │   ├── v1/                                              # API version 1

--- a/services/expense-manager-service/app/main.py
+++ b/services/expense-manager-service/app/main.py
@@ -7,7 +7,6 @@ import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 
-from app.infrastructures.postgres_db.database import init_db
 from app.routers.v1 import router as v1_router
 from app.settings import get_settings
 
@@ -29,9 +28,6 @@ async def lifespan(app: FastAPI):
     """Application lifespan context manager."""
     # Set application start time
     app.state.start_time = datetime.now()
-
-    # Initialize database
-    await init_db()
 
     yield
 

--- a/services/expense-manager-service/app/settings/base.py
+++ b/services/expense-manager-service/app/settings/base.py
@@ -25,6 +25,7 @@ class ExpenseManagerBaseSettings(BaseSettings):
 
     # Database settings
     DATABASE_URL: SecretStr = SecretStr("")
+    PG_DB_HOST: str = "localhost"
     LOG_DB_QUERIES: bool = False
 
     # Logging settings

--- a/services/expense-manager-service/docker-compose.yaml
+++ b/services/expense-manager-service/docker-compose.yaml
@@ -28,6 +28,7 @@ services:
       - PORT=${PORT}
       - DEBUG=${DEBUG}
       - DATABASE_URL=${DATABASE_URL}
+      - PG_DB_HOST=${PG_DB_HOST}
     depends_on:
       - postgres
     networks:

--- a/services/expense-manager-service/entrypoint.sh
+++ b/services/expense-manager-service/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -e
+
+echo "Starting Expense Manager Service..."
+
+echo "Waiting for PostgreSQL to be ready at $PG_DB_HOST:5432..."
+timeout=60
+elapsed=0
+until pg_isready -h "$PG_DB_HOST" -p 5432; do
+  if [ $elapsed -ge $timeout ]; then
+    echo "Timeout: PostgreSQL did not become ready within ${timeout}s"
+    exit 1
+  fi
+  echo "PostgreSQL not ready yet, waiting... (${elapsed}/${timeout}s)"
+  sleep 2
+  elapsed=$((elapsed + 2))
+done
+echo "PostgreSQL is ready!"
+
+# Show current migration version
+echo "Current database migration version:"
+alembic -c app/infrastructures/postgres_db/alembic.ini current
+
+# Show latest migration version
+echo "Latest available migration version:"
+alembic -c app/infrastructures/postgres_db/alembic.ini heads
+
+# Run database migrations
+echo "Running database migrations..."
+alembic -c app/infrastructures/postgres_db/alembic.ini upgrade head
+
+# Show final migration version after upgrade
+echo "Database migration version after upgrade:"
+alembic -c app/infrastructures/postgres_db/alembic.ini current
+
+# Start the application
+echo "Starting FastAPI application..."
+exec python app/main.py


### PR DESCRIPTION
Refactors Docker entrypoints for expense-manager-service, bella-chat-service, and ems-mcp-server to use `entrypoint.sh` scripts.

**Changes:**
- Database migrations moved from lifespan to entrypoint.sh (expense-manager-service)
- Database readiness checks using `pg_isready` with 60s timeout
- Added `PG_DB_HOST` environment variable to configuration files
- Installed `postgresql-client` in Dockerfiles
- bella-chat-service's `orchestrator_agent` remains in lifespan (async context manager)
- Fixed password exposure in logs
- Updated documentation