### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -19,6 +19,7 @@ on:
 env:
   REGISTRY: ghcr.io
   REPO_OWNER: ${{ github.repository_owner }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 # Authentication uses the automatically provided GITHUB_TOKEN.
 
@@ -30,20 +31,20 @@ jobs:
       packages: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.service_path }}
           push: true


### PR DESCRIPTION
## Overview
This PR updates the project's GitHub Actions workflows to use the Node.js 24 runtime, addressing the upcoming deprecation of Node.js 20.

## Changes
- Updated `actions/checkout` from `v4` to `v5`.
- Updated `docker/setup-buildx-action` from `v3` to `v4`.
- Updated `docker/login-action` from `v3` to `v4`.
- Updated `docker/build-push-action` from `v6` to `v7`.
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` to the global environment to ensure all actions opt into the Node 24 runtime.

These updates ensure compatibility with the GitHub Actions runner environment after June 2026.
