### PR TITLE
Fix: Resolve Docker tags from VERSION files or inputs

### DIFF
--- a/.github/workflows/build-bella-chat.yml
+++ b/.github/workflows/build-bella-chat.yml
@@ -26,4 +26,4 @@ jobs:
     with:
       service_path: ./services/bella-chat-service
       image_name: bella-chat-service
-      tag: ${{ inputs.version != '' && inputs.version || format('{0}', github.sha) }}
+      tag: ${{ inputs.version }}

--- a/.github/workflows/build-ems-mcp.yml
+++ b/.github/workflows/build-ems-mcp.yml
@@ -26,4 +26,4 @@ jobs:
     with:
       service_path: ./mcps/ems-mcp-server
       image_name: ems-mcp-server
-      tag: ${{ inputs.version != '' && inputs.version || format('{0}', github.sha) }}
+      tag: ${{ inputs.version }}

--- a/.github/workflows/build-expense-manager.yml
+++ b/.github/workflows/build-expense-manager.yml
@@ -26,4 +26,4 @@ jobs:
     with:
       service_path: ./services/expense-manager-service
       image_name: expense-manager-service
-      tag: ${{ inputs.version != '' && inputs.version || format('{0}', github.sha) }}
+      tag: ${{ inputs.version }}

--- a/.github/workflows/build-keys-ui.yml
+++ b/.github/workflows/build-keys-ui.yml
@@ -26,4 +26,4 @@ jobs:
     with:
       service_path: ./keys-personal-assist-ui
       image_name: keys-personal-assist-ui
-      tag: ${{ inputs.version != '' && inputs.version || format('{0}', github.sha) }}
+      tag: ${{ inputs.version }}

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -12,8 +12,8 @@ on:
         required: true
         type: string
       tag:
-        description: "Image tag"
-        required: true
+        description: "Image tag (optional, will read VERSION file if not provided)"
+        required: false
         type: string
 
 env:
@@ -43,17 +43,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve Docker Tag
+        id: resolve-tag
+        run: |
+          if [ -n "${{ inputs.tag }}" ]; then
+            echo "resolved_tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          elif [ -f "${{ inputs.service_path }}/VERSION" ]; then
+            echo "resolved_tag=$(cat ${{ inputs.service_path }}/VERSION)" >> $GITHUB_OUTPUT
+          else
+            echo "resolved_tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         with:
           context: ${{ inputs.service_path }}
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ inputs.image_name }}:${{ inputs.tag }}
+            ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ inputs.image_name }}:${{ steps.resolve-tag.outputs.resolved_tag }}
             ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ inputs.image_name }}:latest
           labels: |
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.revision=${{ github.sha }}
-            org.opencontainers.image.version=${{ inputs.tag }}
+            org.opencontainers.image.version=${{ steps.resolve-tag.outputs.resolved_tag }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
### Description

This PR resolves an issue where Docker image builds in CI were defaulting to tagging images with `github.sha` instead of the semantic version from the service `VERSION` files.

### Changes Made

- **Reusable Workflow (`reusable-docker-build.yml`)**:
  - Made the `tag` input optional.
  - Added a step to dynamically read the service's `VERSION` file if no tag is provided.
  - Changed the output to use `$GITHUB_OUTPUT` to satisfy linting requirements.
- **Caller Workflows**:
  - Removed the hardcoded `github.sha` fallback from `build-keys-ui.yml`, `build-expense-manager.yml`, `build-ems-mcp.yml`, and `build-bella-chat.yml`.
