### PR TITLE
Fix: Use VERSION file instead of SHA for push-triggered builds

### DIFF
--- a/.github/workflows/build-bella-chat.yml
+++ b/.github/workflows/build-bella-chat.yml
@@ -18,7 +18,22 @@ env:
   REPO_OWNER: ${{ github.repository_owner }}
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Read VERSION file
+        id: version
+        run: |
+          VERSION=$(cat services/bella-chat-service/VERSION)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   build:
+    needs: get-version
     uses: ./.github/workflows/reusable-docker-build.yml
     permissions:
       contents: read
@@ -26,4 +41,4 @@ jobs:
     with:
       service_path: ./services/bella-chat-service
       image_name: bella-chat-service
-      tag: ${{ inputs.version }}
+      tag: ${{ inputs.version != '' && inputs.version || needs.get-version.outputs.version }}

--- a/.github/workflows/build-ems-mcp.yml
+++ b/.github/workflows/build-ems-mcp.yml
@@ -18,7 +18,22 @@ env:
   REPO_OWNER: ${{ github.repository_owner }}
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Read VERSION file
+        id: version
+        run: |
+          VERSION=$(cat mcps/ems-mcp-server/VERSION)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   build:
+    needs: get-version
     uses: ./.github/workflows/reusable-docker-build.yml
     permissions:
       contents: read
@@ -26,4 +41,4 @@ jobs:
     with:
       service_path: ./mcps/ems-mcp-server
       image_name: ems-mcp-server
-      tag: ${{ inputs.version }}
+      tag: ${{ inputs.version != '' && inputs.version || needs.get-version.outputs.version }}

--- a/.github/workflows/build-expense-manager.yml
+++ b/.github/workflows/build-expense-manager.yml
@@ -18,7 +18,22 @@ env:
   REPO_OWNER: ${{ github.repository_owner }}
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Read VERSION file
+        id: version
+        run: |
+          VERSION=$(cat services/expense-manager-service/VERSION)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   build:
+    needs: get-version
     uses: ./.github/workflows/reusable-docker-build.yml
     permissions:
       contents: read
@@ -26,4 +41,4 @@ jobs:
     with:
       service_path: ./services/expense-manager-service
       image_name: expense-manager-service
-      tag: ${{ inputs.version }}
+      tag: ${{ inputs.version != '' && inputs.version || needs.get-version.outputs.version }}

--- a/.github/workflows/build-keys-ui.yml
+++ b/.github/workflows/build-keys-ui.yml
@@ -18,7 +18,22 @@ env:
   REPO_OWNER: ${{ github.repository_owner }}
 
 jobs:
+  get-version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Read VERSION file
+        id: version
+        run: |
+          VERSION=$(cat keys-personal-assist-ui/VERSION)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
   build:
+    needs: get-version
     uses: ./.github/workflows/reusable-docker-build.yml
     permissions:
       contents: read
@@ -26,4 +41,4 @@ jobs:
     with:
       service_path: ./keys-personal-assist-ui
       image_name: keys-personal-assist-ui
-      tag: ${{ inputs.version }}
+      tag: ${{ inputs.version != '' && inputs.version || needs.get-version.outputs.version }}


### PR DESCRIPTION
Fixes workflow to read VERSION file content when triggered by push, eliminating SHA-based image tags.