### PR TITLE
Improve CI debuggability: Add version visibility

### DIFF
--- a/.github/workflows/build-bella-chat.yml
+++ b/.github/workflows/build-bella-chat.yml
@@ -30,6 +30,7 @@ jobs:
         id: version
         run: |
           VERSION=$(cat services/bella-chat-service/VERSION)
+          echo "📦 Building version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   build:

--- a/.github/workflows/build-ems-mcp.yml
+++ b/.github/workflows/build-ems-mcp.yml
@@ -30,6 +30,7 @@ jobs:
         id: version
         run: |
           VERSION=$(cat mcps/ems-mcp-server/VERSION)
+          echo "📦 Building version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   build:

--- a/.github/workflows/build-expense-manager.yml
+++ b/.github/workflows/build-expense-manager.yml
@@ -30,6 +30,7 @@ jobs:
         id: version
         run: |
           VERSION=$(cat services/expense-manager-service/VERSION)
+          echo "📦 Building version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   build:

--- a/.github/workflows/build-keys-ui.yml
+++ b/.github/workflows/build-keys-ui.yml
@@ -30,6 +30,7 @@ jobs:
         id: version
         run: |
           VERSION=$(cat keys-personal-assist-ui/VERSION)
+          echo "📦 Building version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   build:

--- a/.github/workflows/reusable-docker-build.yml
+++ b/.github/workflows/reusable-docker-build.yml
@@ -47,13 +47,17 @@ jobs:
         id: resolve-tag
         run: |
           if [ -n "${{ inputs.tag }}" ]; then
-            echo "resolved_tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            TAG="${{ inputs.tag }}"
+            echo "🔖 Using provided tag: $TAG"
           elif [ -f "${{ inputs.service_path }}/VERSION" ]; then
-            echo "resolved_tag=$(cat ${{ inputs.service_path }}/VERSION)" >> $GITHUB_OUTPUT
+            TAG=$(cat ${{ inputs.service_path }}/VERSION)
+            echo "🔖 Using VERSION file: $TAG"
           else
-            echo "resolved_tag=${{ github.sha }}" >> $GITHUB_OUTPUT
+            TAG="${{ github.sha }}"
+            echo "🔖 Using git SHA: $TAG"
           fi
-
+          echo "resolved_tag=$TAG" >> $GITHUB_OUTPUT
+          echo "📤 Image: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ inputs.image_name }}:$TAG"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7


### PR DESCRIPTION
Adds debug output to CI pipelines so version information is visible in logs.

## Changes
- Service workflows: Print 📦 Building version: X.Y.Z before setting output
- Reusable workflow: Print tag resolution source (provided/VERSION file/SHA)
- Reusable workflow: Print final image name with tag

## Why
Previously version was written to GITHUB_OUTPUT but never displayed in logs, making it hard to verify what version was being built.

Signed-off-by: Keys (Shangar) <shangar202000@gmail.com>