### PR TITLE
Implement Account Management and Inline Quick-Add UI

### DIFF
--- a/keys-personal-assist-ui/src/components/AccountManagementModal.tsx
+++ b/keys-personal-assist-ui/src/components/AccountManagementModal.tsx
@@ -1,0 +1,291 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  IconButton,
+  List,
+  ListItem,
+  Typography,
+  Box,
+  Divider,
+  CircularProgress,
+  DialogContentText,
+} from '@mui/material';
+import {
+  Delete as Trash2,
+  Edit,
+  Check,
+  Close,
+  Add as Plus,
+  WarningAmber,
+} from '@mui/icons-material';
+import { emsClient } from '@/api/clients/ems-client';
+import type { AccountNameResponse } from '@/types/api';
+import { toast } from 'sonner';
+
+interface AccountManagementModalProps {
+  open: boolean;
+  onClose: (hasChanges: boolean) => void;
+}
+
+export default function AccountManagementModal({ open, onClose }: AccountManagementModalProps) {
+  const [accounts, setAccounts] = useState<AccountNameResponse[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [newAccountName, setNewAccountName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  
+  // Deletion Confirmation States
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  const fetchAccounts = async () => {
+    setLoading(true);
+    try {
+      const data = await emsClient.getAllAccounts();
+      setAccounts(data);
+    } catch {
+      toast.error('Failed to load accounts');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (open) {
+      fetchAccounts();
+      setHasChanges(false);
+      setNewAccountName('');
+      setEditingId(null);
+      setDeleteConfirmId(null);
+    }
+  }, [open]);
+
+  const handleCreateAccount = async () => {
+    if (!newAccountName.trim()) {
+      toast.error('Account name cannot be empty');
+      return;
+    }
+    setLoading(true);
+    try {
+      await emsClient.getOrCreateAccount({ accountName: newAccountName.trim() });
+      toast.success(`Account "${newAccountName.trim()}" created successfully`);
+      setNewAccountName('');
+      setHasChanges(true);
+      await fetchAccounts();
+    } catch (e: any) {
+      toast.error(e.message || 'Failed to create account');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleStartEdit = (id: string, currentName: string) => {
+    setEditingId(id);
+    setEditingName(currentName);
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditingName('');
+  };
+
+  const handleSaveEdit = async (id: string) => {
+    if (!editingName.trim()) {
+      toast.error('Account name cannot be empty');
+      return;
+    }
+    setLoading(true);
+    try {
+      await emsClient.updateAccountName(id, { accountName: editingName.trim() });
+      toast.success('Account renamed successfully');
+      setEditingId(null);
+      setHasChanges(true);
+      await fetchAccounts();
+    } catch (e: any) {
+      toast.error(e.message || 'Failed to update account');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDeleteAccount = async () => {
+    if (!deleteConfirmId) return;
+    setLoading(true);
+    try {
+      await emsClient.deleteAccount(deleteConfirmId);
+      toast.success('Account and all associated entries deleted successfully');
+      setDeleteConfirmId(null);
+      setHasChanges(true);
+      await fetchAccounts();
+    } catch (e: any) {
+      toast.error(e.message || 'Failed to delete account');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={() => onClose(hasChanges)} maxWidth="sm" fullWidth>
+        <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>
+          Manage Bank Accounts
+        </DialogTitle>
+        <DialogContent dividers>
+          {/* New Account Creation Form */}
+          <Box sx={{ display: 'flex', gap: 2, mb: 3, mt: 1 }}>
+            <TextField
+              fullWidth
+              size="small"
+              label="New Account Name"
+              placeholder="e.g. Chase Bank, HDFC Savings, Cash Wallet"
+              value={newAccountName}
+              onChange={(e) => setNewAccountName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleCreateAccount();
+                }
+              }}
+              disabled={loading}
+            />
+            <Button
+              variant="contained"
+              startIcon={<Plus />}
+              onClick={handleCreateAccount}
+              disabled={loading || !newAccountName.trim()}
+              sx={{ px: 3 }}
+            >
+              Add
+            </Button>
+          </Box>
+
+          <Divider sx={{ my: 2 }} />
+
+          <Typography variant="subtitle2" sx={{ fontWeight: 700, mb: 1, color: 'text.secondary' }}>
+            Existing Accounts ({accounts.length})
+          </Typography>
+
+          {loading && accounts.length === 0 ? (
+            <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+              <CircularProgress size={24} />
+            </Box>
+          ) : accounts.length === 0 ? (
+            <Typography variant="body2" color="text.secondary" sx={{ py: 3, textAlign: 'center' }}>
+              No accounts registered. Create one above to get started.
+            </Typography>
+          ) : (
+            <List sx={{ width: '100%', bgcolor: 'background.paper', borderRadius: 1 }}>
+              {accounts.map((account) => {
+                const isEditing = editingId === account.id;
+                return (
+                  <ListItem
+                    key={account.id}
+                    divider
+                    secondaryAction={
+                      isEditing ? (
+                        <Box sx={{ display: 'flex', gap: 0.5 }}>
+                          <IconButton
+                            edge="end"
+                            size="small"
+                            color="success"
+                            onClick={() => handleSaveEdit(account.id)}
+                            disabled={loading || !editingName.trim()}
+                          >
+                            <Check fontSize="small" />
+                          </IconButton>
+                          <IconButton
+                            edge="end"
+                            size="small"
+                            color="error"
+                            onClick={handleCancelEdit}
+                            disabled={loading}
+                          >
+                            <Close fontSize="small" />
+                          </IconButton>
+                        </Box>
+                      ) : (
+                        <Box sx={{ display: 'flex', gap: 0.5 }}>
+                          <IconButton
+                            edge="end"
+                            size="small"
+                            color="primary"
+                            onClick={() => handleStartEdit(account.id, account.accountName)}
+                            disabled={loading}
+                          >
+                            <Edit fontSize="small" />
+                          </IconButton>
+                          <IconButton
+                            edge="end"
+                            size="small"
+                            color="error"
+                            onClick={() => setDeleteConfirmId(account.id)}
+                            disabled={loading}
+                          >
+                            <Trash2 fontSize="small" />
+                          </IconButton>
+                        </Box>
+                      )
+                    }
+                    sx={{ py: 1.5 }}
+                  >
+                    {isEditing ? (
+                      <TextField
+                        fullWidth
+                        size="small"
+                        value={editingName}
+                        onChange={(e) => setEditingName(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            handleSaveEdit(account.id);
+                          }
+                        }}
+                        autoFocus
+                      />
+                    ) : (
+                      <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                        {account.accountName}
+                      </Typography>
+                    )}
+                  </ListItem>
+                );
+              })}
+            </List>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ px: 3, py: 2 }}>
+          <Button onClick={() => onClose(hasChanges)} variant="outlined">
+            Close
+          </Button>
+        </DialogActions>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog
+        open={deleteConfirmId !== null}
+        onClose={() => setDeleteConfirmId(null)}
+        maxWidth="xs"
+      >
+        <DialogTitle sx={{ display: 'flex', alignItems: 'center', gap: 1, color: 'error.main', fontWeight: 700 }}>
+          <WarningAmber /> Warning: Delete Account?
+        </DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Deleting this account will permanently delete all associated ledger entries, monthly expenses, and savings buckets. This action is irreversible.
+          </DialogContentText>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 3 }}>
+          <Button onClick={() => setDeleteConfirmId(null)}>Cancel</Button>
+          <Button onClick={handleDeleteAccount} variant="contained" color="error">
+            Delete Irreversibly
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+}

--- a/keys-personal-assist-ui/src/pages/SavingsFundSegregatorPage.tsx
+++ b/keys-personal-assist-ui/src/pages/SavingsFundSegregatorPage.tsx
@@ -25,8 +25,10 @@ import {
   TextField,
   Chip,
   LinearProgress,
+  Tooltip as MuiTooltip,
 } from '@mui/material';
 import { Grid } from '@mui/material';
+import AccountManagementModal from '@/components/AccountManagementModal';
 import {
   Add as Plus,
   Edit,
@@ -38,6 +40,7 @@ import {
   ArrowUpward,
   ArrowDownward,
   Block,
+  Settings,
 } from '@mui/icons-material';
 import { toast } from 'sonner';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from 'recharts';
@@ -84,13 +87,22 @@ export default function SavingsFundSegregatorPage() {
   const [selectedTx, setSelectedTx] = useState<SavingsBucketTransactionResponse | null>(null);
   const [cancelReason, setCancelReason] = useState('');
 
+  const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
+
   // ── Data Fetching ────────────────────────────────────────────────────────────
-  const fetchAccounts = async () => {
+  const fetchAccounts = async (keepSelection = false) => {
     try {
       const data = await emsClient.getAllAccounts();
       setAccounts(data);
       if (data.length > 0) {
-        setSelectedAccountId(data[0].id);
+        const exists = data.some(acc => acc.id === selectedAccountId);
+        if (keepSelection && selectedAccountId && exists) {
+          // Keep current selection
+        } else {
+          setSelectedAccountId(data[0].id);
+        }
+      } else {
+        setSelectedAccountId('');
       }
     } catch {
       toast.error('Failed to fetch bank accounts');
@@ -324,23 +336,34 @@ export default function SavingsFundSegregatorPage() {
             </Typography>
           </Box>
 
-          <FormControl sx={{ minWidth: 240 }} size="small">
-            <InputLabel>Bank Account</InputLabel>
-            <Select
-              value={selectedAccountId}
-              label="Bank Account"
-              onChange={(e) => {
-                setSelectedAccountId(e.target.value);
-                setPage(0);
-              }}
-            >
-              {accounts.map((acc) => (
-                <MenuItem key={acc.id} value={acc.id}>
-                  {acc.accountName}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <FormControl sx={{ minWidth: 240 }} size="small">
+              <InputLabel>Bank Account</InputLabel>
+              <Select
+                value={selectedAccountId}
+                label="Bank Account"
+                onChange={(e) => {
+                  setSelectedAccountId(e.target.value);
+                  setPage(0);
+                }}
+              >
+                {accounts.map((acc) => (
+                  <MenuItem key={acc.id} value={acc.id}>
+                    {acc.accountName}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+            <MuiTooltip title="Manage Accounts">
+              <IconButton
+                size="small"
+                onClick={() => setIsAccountModalOpen(true)}
+                color="primary"
+              >
+                <Settings fontSize="small" />
+              </IconButton>
+            </MuiTooltip>
+          </Box>
         </Box>
 
         {/* ── Metric Cards ── */}
@@ -882,6 +905,17 @@ export default function SavingsFundSegregatorPage() {
             </Button>
           </DialogActions>
         </Dialog>
+
+        {/* Account Management Modal */}
+        <AccountManagementModal
+          open={isAccountModalOpen}
+          onClose={(changes) => {
+            setIsAccountModalOpen(false);
+            if (changes) {
+              fetchAccounts(true);
+            }
+          }}
+        />
       </Container>
     </Box>
   );

--- a/keys-personal-assist-ui/src/pages/SpendingAccountSummaryPage.tsx
+++ b/keys-personal-assist-ui/src/pages/SpendingAccountSummaryPage.tsx
@@ -26,6 +26,7 @@ import {
   TextField,
   Chip,
   OutlinedInput,
+  Tooltip,
 } from '@mui/material';
 import { Grid } from '@mui/material';
 import {
@@ -37,9 +38,11 @@ import {
   AccountBalance,
   CreditCard,
   Payments,
+  Settings,
 } from '@mui/icons-material';
 import { toast } from 'sonner';
 import { emsClient } from '@/api/clients/ems-client';
+import AccountManagementModal from '@/components/AccountManagementModal';
 import type {
   SpendingAccountEntryWithCalculatedFieldsResponse,
   SpendingEntryWithCalcPageResponse,
@@ -94,23 +97,31 @@ interface EntryFormFieldsProps {
   formData: FormData;
   accounts: string[];
   onChange: (next: FormData) => void;
+  onAddAccountClick: () => void;
 }
 
-function EntryFormFields({ formData, accounts, onChange }: EntryFormFieldsProps) {
+function EntryFormFields({ formData, accounts, onChange, onAddAccountClick }: EntryFormFieldsProps) {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2, pt: 2 }}>
-      <FormControl fullWidth>
-        <InputLabel>Account</InputLabel>
-        <Select
-          value={formData.accountName}
-          label="Account"
-          onChange={(e) => onChange({ ...formData, accountName: e.target.value })}
-        >
-          {accounts.map((a) => (
-            <MenuItem key={a} value={a}>{a}</MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+        <FormControl fullWidth>
+          <InputLabel>Account</InputLabel>
+          <Select
+            value={formData.accountName}
+            label="Account"
+            onChange={(e) => onChange({ ...formData, accountName: e.target.value })}
+          >
+            {accounts.map((a) => (
+              <MenuItem key={a} value={a}>{a}</MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <Tooltip title="Add New Account">
+          <IconButton onClick={onAddAccountClick} color="primary">
+            <Plus />
+          </IconButton>
+        </Tooltip>
+      </Box>
 
       <FormControl fullWidth>
         <InputLabel>Month</InputLabel>
@@ -185,6 +196,11 @@ export default function SpendingAccountSummaryPage() {
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
   const [selectedEntry, setSelectedEntry] = useState<SpendingAccountEntry | null>(null);
   const [formData, setFormData] = useState<FormData>(DEFAULT_FORM);
+
+  const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
+  const [isQuickAddAccountOpen, setIsQuickAddAccountOpen] = useState(false);
+  const [quickAddAccountName, setQuickAddAccountName] = useState('');
+  const [quickAddLoading, setQuickAddLoading] = useState(false);
 
   // ── Derived values for metric cards ─────────────────────────────────────────
   const now = new Date();
@@ -288,6 +304,26 @@ export default function SpendingAccountSummaryPage() {
       fetchEntries();
     } catch {
       toast.error('Failed to delete entry');
+    }
+  };
+
+  const handleQuickAddAccount = async () => {
+    if (!quickAddAccountName.trim()) {
+      toast.error('Account name cannot be empty');
+      return;
+    }
+    setQuickAddLoading(true);
+    try {
+      await emsClient.getOrCreateAccount({ accountName: quickAddAccountName.trim() });
+      toast.success(`Account "${quickAddAccountName.trim()}" created successfully`);
+      setFormData(prev => ({ ...prev, accountName: quickAddAccountName.trim() }));
+      setQuickAddAccountName('');
+      setIsQuickAddAccountOpen(false);
+      await fetchAccounts();
+    } catch (e: any) {
+      toast.error(e.message || 'Failed to create account');
+    } finally {
+      setQuickAddLoading(false);
     }
   };
 
@@ -443,21 +479,32 @@ export default function SpendingAccountSummaryPage() {
             <Grid container spacing={2} alignItems="center">
               {/* Account filter */}
               <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                <FormControl fullWidth size="small">
-                  <InputLabel shrink>Account</InputLabel>
-                  <Select
-                    value={filterAccount}
-                    displayEmpty
-                    input={<OutlinedInput notched label="Account" />}
-                    onChange={(e) => { setFilterAccount(e.target.value); setPage(0); }}
-                    renderValue={(v: string) => v || <em style={{ color: '#9e9e9e' }}>All Accounts</em>}
-                  >
-                    <MenuItem value="">All Accounts</MenuItem>
-                    {accounts.map((a) => (
-                      <MenuItem key={a} value={a}>{a}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <FormControl fullWidth size="small">
+                    <InputLabel shrink>Account</InputLabel>
+                    <Select
+                      value={filterAccount}
+                      displayEmpty
+                      input={<OutlinedInput notched label="Account" />}
+                      onChange={(e) => { setFilterAccount(e.target.value); setPage(0); }}
+                      renderValue={(v: string) => v || <em style={{ color: '#9e9e9e' }}>All Accounts</em>}
+                    >
+                      <MenuItem value="">All Accounts</MenuItem>
+                      {accounts.map((a) => (
+                        <MenuItem key={a} value={a}>{a}</MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                  <Tooltip title="Manage Accounts">
+                    <IconButton
+                      size="small"
+                      onClick={() => setIsAccountModalOpen(true)}
+                      color="primary"
+                    >
+                      <Settings fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Box>
               </Grid>
 
               {/* Month filter */}
@@ -621,7 +668,7 @@ export default function SpendingAccountSummaryPage() {
         <Dialog open={isAddModalOpen} onClose={() => setIsAddModalOpen(false)} maxWidth="sm" fullWidth>
           <DialogTitle>Add New Entry</DialogTitle>
           <DialogContent>
-            <EntryFormFields formData={formData} accounts={accounts} onChange={setFormData} />
+            <EntryFormFields formData={formData} accounts={accounts} onChange={setFormData} onAddAccountClick={() => setIsQuickAddAccountOpen(true)} />
           </DialogContent>
           <DialogActions>
             <Button onClick={() => setIsAddModalOpen(false)}>Cancel</Button>
@@ -633,7 +680,7 @@ export default function SpendingAccountSummaryPage() {
         <Dialog open={isEditModalOpen} onClose={() => setIsEditModalOpen(false)} maxWidth="sm" fullWidth>
           <DialogTitle>Edit Entry</DialogTitle>
           <DialogContent>
-            <EntryFormFields formData={formData} accounts={accounts} onChange={setFormData} />
+            <EntryFormFields formData={formData} accounts={accounts} onChange={setFormData} onAddAccountClick={() => setIsQuickAddAccountOpen(true)} />
           </DialogContent>
           <DialogActions>
             <Button onClick={() => setIsEditModalOpen(false)}>Cancel</Button>
@@ -652,6 +699,56 @@ export default function SpendingAccountSummaryPage() {
           <DialogActions>
             <Button onClick={() => setIsDeleteModalOpen(false)}>Cancel</Button>
             <Button onClick={handleDeleteEntry} variant="contained" color="error">Delete</Button>
+          </DialogActions>
+        </Dialog>
+
+        {/* Account Management Modal */}
+        <AccountManagementModal
+          open={isAccountModalOpen}
+          onClose={(changes) => {
+            setIsAccountModalOpen(false);
+            if (changes) {
+              fetchAccounts();
+              fetchEntries();
+            }
+          }}
+        />
+
+        {/* Inline Quick-Add Account Dialog */}
+        <Dialog
+          open={isQuickAddAccountOpen}
+          onClose={() => setIsQuickAddAccountOpen(false)}
+          maxWidth="xs"
+          fullWidth
+        >
+          <DialogTitle sx={{ fontWeight: 700 }}>Quick Add Account</DialogTitle>
+          <DialogContent>
+            <TextField
+              fullWidth
+              size="small"
+              label="Account Name"
+              placeholder="e.g. Citi Bank"
+              value={quickAddAccountName}
+              onChange={(e) => setQuickAddAccountName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  handleQuickAddAccount();
+                }
+              }}
+              disabled={quickAddLoading}
+              sx={{ mt: 1 }}
+            />
+          </DialogContent>
+          <DialogActions sx={{ px: 3, pb: 3 }}>
+            <Button onClick={() => setIsQuickAddAccountOpen(false)}>Cancel</Button>
+            <Button
+              onClick={handleQuickAddAccount}
+              variant="contained"
+              disabled={quickAddLoading || !quickAddAccountName.trim()}
+            >
+              Create
+            </Button>
           </DialogActions>
         </Dialog>
       </Container>


### PR DESCRIPTION
### Summary of Changes

This PR resolves the gap where users were unable to manage or create bank/spending accounts from the UI. It integrates complete account CRUD functionalities into the React application:

1. **New Account Management Component**:
   - Created `AccountManagementModal.tsx` in UI components, allowing users to list, create, inline rename, and delete bank/spending accounts.
   - Includes safety checks and warn dialogs when deleting accounts since it cascades to ledger entries, expenses, and savings buckets.

2. **Integration into Summary and Segregator Dashboards**:
   - Integrated the modal into `SpendingAccountSummaryPage.tsx` and `SavingsFundSegregatorPage.tsx` using a settings gear icon next to selectors.
   - Refetched and updated account lists dynamically when accounts are modified.
   - Improved active view selection preservation when accounts are renamed.

3. **Inline Quick-Add (Add Entry Dialog)**:
   - Added an inline quick-add "+" button next to the account select field in the Add/Edit Entry forms.
   - Clicking "+" opens a simple dialog to input the name of a new account, which is created on the backend and automatically selected in the select field.

4. **Verification**:
   - Verified that the TypeScript builds cleanly with zero errors (`npx tsc -b`).
   - Verified local launcher container spinup using `scripts/run-dev.sh`.
