### PR TITLE
Align Docker Compose host fallbacks and fix .env typo

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -15,7 +15,7 @@ EMS_PG_DB_HOST=host.docker.internal
 EMS_PG_DB_USER=ems_user
 EMS_PG_DB_PASSWORD=your_password_here
 EMS_PG_DB_NAME=expense_manager_dev
-EMS_PG_DATABASE_URL=postgresql+asyncpg://ems_user:your_password_here@$host.docker.internal:5432/expense_manager_dev
+EMS_PG_DATABASE_URL=postgresql+asyncpg://ems_user:your_password_here@host.docker.internal:5432/expense_manager_dev
 # -----------------------------------------------
 
 # ------------- Bella Chat Service --------------

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
       # Database configurations
       - STORAGE_TYPE=${EMS_STORAGE_TYPE}
       - DATABASE_URL=${EMS_PG_DATABASE_URL}
-      - PG_DB_HOST=${EMS_PG_DB_HOST}
+      - PG_DB_HOST=${EMS_PG_DB_HOST:-host.docker.internal}
     networks:
       - bella-network-dev
     logging:
@@ -52,7 +52,7 @@ services:
       # Ollama Settings
       - OLLAMA_URL=${OLLAMA_URL}
       # QDRANT Settings
-      - QDRANT_URL=${QDRANT_URL}
+      - QDRANT_URL=${QDRANT_URL:-http://host.docker.internal:6333}
       # Keys Personal Wiki Agent Settings
       - QDRANT_COLLECTION_NAME=${QDRANT_COLLECTION_NAME}
       # EMS MCP Server Settings
@@ -63,12 +63,12 @@ services:
       - ARIZE_PROJECT_NAME=${ARIZE_PROJECT_NAME}
       - ARIZE_PG_DB_USER=${ARIZE_PG_DB_USER}
       - ARIZE_PG_DB_PASSWORD=${ARIZE_PG_DB_PASSWORD}
-      - ARIZE_PG_DB_HOST=${ARIZE_PG_DB_HOST}
+      - ARIZE_PG_DB_HOST=${ARIZE_PG_DB_HOST:-host.docker.internal}
       - ARIZE_PG_DB_NAME=${ARIZE_PG_DB_NAME}
       # LangGraph Postgres Checkpointer
       - LANGGRAPH_PG_DB_USER=${LANGGRAPH_PG_DB_USER}
       - LANGGRAPH_PG_DB_PASSWORD=${LANGGRAPH_PG_DB_PASSWORD}
-      - LANGGRAPH_PG_DB_HOST=${LANGGRAPH_PG_DB_HOST}
+      - LANGGRAPH_PG_DB_HOST=${LANGGRAPH_PG_DB_HOST:-host.docker.internal}
       - LANGGRAPH_PG_DB_NAME=${LANGGRAPH_PG_DB_NAME}
       - ORCHESTRATOR_MAX_ITERATIONS=${ORCHESTRATOR_MAX_ITERATIONS}
     depends_on:
@@ -130,7 +130,7 @@ services:
       - 4317:4317 # PHOENIX_GRPC_PORT
       - 9090:9090 # [Optional] PROMETHEUS PORT IF ENABLED
     environment:
-      - PHOENIX_SQL_DATABASE_URL=postgresql://${ARIZE_PG_DB_USER}:${ARIZE_PG_DB_PASSWORD}@${ARIZE_PG_DB_HOST}:5432/${ARIZE_PG_DB_NAME}
+      - PHOENIX_SQL_DATABASE_URL=postgresql://${ARIZE_PG_DB_USER}:${ARIZE_PG_DB_PASSWORD}@${ARIZE_PG_DB_HOST:-host.docker.internal}:5432/${ARIZE_PG_DB_NAME}
     networks:
       - bella-network-dev
     logging:


### PR DESCRIPTION
## Summary of Changes

This PR aligns the development and production Docker Compose environment configurations to improve developer onboarding and local resilience.

1. **Bug Fix (.env.example):**
   - Fixed a syntax typo in the PostgreSQL connection string `EMS_PG_DATABASE_URL` (removed the erroneous `$` prefix from the host name).

2. **Align Dev with Prod Host Fallbacks:**
   - Added standard host variable fallbacks (`:-host.docker.internal` or default port fallbacks) in the development `docker/docker-compose.yaml` to ensure services start correctly even if developer `.env` files omit explicit host settings. Affected variables:
     - `PG_DB_HOST`
     - `QDRANT_URL`
     - `ARIZE_PG_DB_HOST`
     - `LANGGRAPH_PG_DB_HOST`
     - `PHOENIX_SQL_DATABASE_URL`

## Verification

Verified both Docker Compose files syntactically using the configuration parser:
- `docker compose -f docker/docker-compose.yaml config` -> Passed
- `docker compose -f docker/docker-compose-prod.yaml config` -> Passed
