### PR TITLE
Standardize Finance module pages and navigation layout

### DIFF
--- a/keys-personal-assist-ui/src/components/AppShell.tsx
+++ b/keys-personal-assist-ui/src/components/AppShell.tsx
@@ -24,7 +24,6 @@ import {
 } from '@mui/material';
 import {
     AutoAwesome as Sparkles,
-    BarChart as BarChart3,
     CalendarMonth,
     Chat as MessageCircle,
     ChevronLeft,
@@ -84,21 +83,14 @@ const getNavSections = (): NavSection[] => {
             section: 'Finance',
             items: [
                 {
-                    name: 'Dashboard',
-                    href: '/dashboard',
-                    icon: BarChart3,
-                    children: [
-                        {
-                            name: 'Account Balances',
-                            href: '/dashboard/accounts',
-                            icon: CreditCard,
-                        },
-                        {
-                            name: 'Savings Envelopes',
-                            href: '/dashboard/envelopes',
-                            icon: AccountBalanceWallet,
-                        },
-                    ],
+                    name: 'Spending Accounts',
+                    href: '/dashboard/accounts',
+                    icon: CreditCard,
+                },
+                {
+                    name: 'Savings Envelopes',
+                    href: '/dashboard/envelopes',
+                    icon: AccountBalanceWallet,
                 },
                 {
                     name: 'Monthly Budget',
@@ -130,7 +122,7 @@ const LINK_STYLE = { textDecoration: 'none', color: 'inherit', display: 'block' 
 export default function AppShell({ children }: { children: ReactNode }) {
     const [open, setOpen] = useState(true);
     const [mobileOpen, setMobileOpen] = useState(false);
-    const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({ Dashboard: true });
+    const [expandedItems, setExpandedItems] = useState<Record<string, boolean>>({});
     const location = useLocation();
     const { mode, toggleTheme } = useThemeMode();
     const theme = useTheme();

--- a/keys-personal-assist-ui/src/components/wealth/AssetsTab.tsx
+++ b/keys-personal-assist-ui/src/components/wealth/AssetsTab.tsx
@@ -46,7 +46,7 @@ import {
 } from '@mui/icons-material';
 import { emsClient } from '@/api/clients/ems-client';
 import type { Asset, AssetSummary, AssetUpdateRequest, AssetCategory } from '@/types/asset';
-import { formatCurrency } from '@/utils/formatters';
+import { formatCurrency, formatCompactRupees } from '@/utils/formatters';
 import { toast } from 'sonner';
 import AddAssetWizard from './AddAssetWizard';
 import AssetTransactionsModal from './AssetTransactionsModal';
@@ -56,25 +56,6 @@ import AssetTransactionsModal from './AssetTransactionsModal';
 interface AssetsTabProps {
   onAssetsLoad?: (count: number) => void;
 }
-
-// Compact currency formatter for INR
-export const formatCompactRupees = (value: number): string => {
-  if (value === 0) return '₹0.00';
-  const isNegative = value < 0;
-  const absVal = Math.abs(value);
-  let result = '';
-
-  if (absVal >= 10000000) {
-    result = `₹${(absVal / 10000000).toFixed(2)} Cr`;
-  } else if (absVal >= 100000) {
-    result = `₹${(absVal / 100000).toFixed(2)}L`;
-  } else {
-    result = formatCurrency(absVal);
-    return isNegative ? `-${result}` : result;
-  }
-  
-  return isNegative ? `-${result}` : result;
-};
 
 export default function AssetsTab({ onAssetsLoad }: AssetsTabProps) {
   const theme = useTheme();

--- a/keys-personal-assist-ui/src/pages/MonthlyPlannerPage.tsx
+++ b/keys-personal-assist-ui/src/pages/MonthlyPlannerPage.tsx
@@ -27,6 +27,9 @@ import {  Box,
   Stack,
   Tab,
   Tabs,
+  Paper,
+  OutlinedInput,
+  Tooltip,
 } from '@mui/material';
 import { Grid } from '@mui/material';
 import {
@@ -45,7 +48,7 @@ import type {
   MonthlyExpenseItem,
   MonthlyExpenseItemRequest,
 } from '@/types/api';
-import { formatCurrency } from '@/utils/formatters';
+import { formatCurrency, formatCompactRupees } from '@/utils/formatters';
 import { PieChart, Pie, Cell, ResponsiveContainer, Legend, Tooltip as RechartsTooltip } from 'recharts';
 
 const MONTH_NAMES = [
@@ -100,6 +103,8 @@ export default function MonthlyPlannerPage() {
   const [summary, setSummary] = useState<MonthlySummary | null>(null);
   const [expenses, setExpenses] = useState<MonthlyExpenseItem[]>([]);
   const [categories, setCategories] = useState<MonthlyCategory[]>([]);
+  const [isEditingSalary, setIsEditingSalary] = useState(false);
+  const [salaryInputVal, setSalaryInputVal] = useState('');
   
   const [isExpenseModalOpen, setIsExpenseModalOpen] = useState(false);
   const [editingExpense, setEditingExpense] = useState<MonthlyExpenseItem | null>(null);
@@ -301,24 +306,48 @@ export default function MonthlyPlannerPage() {
     setIsExpenseModalOpen(true);
   };
 
+  const handleSaveSalary = () => {
+    setIsEditingSalary(false);
+    handleUpdateSalary(salaryInputVal);
+  };
+
   return (
-    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', pb: 8 }}>
-      <Container maxWidth="xl" sx={{ py: 4 }}>
+    <Box
+      sx={{
+        flexGrow: 1,
+        bgcolor: 'background.default',
+        py: 2.5,
+        px: { xs: 2, md: 4 },
+        backgroundImage: (theme) =>
+          theme.palette.mode === 'dark'
+            ? 'radial-gradient(circle at 10% 20%, rgba(30, 41, 59, 0.4) 0%, rgba(17, 24, 39, 0.95) 90%)'
+            : 'none',
+        transition: 'background-color 0.3s ease',
+        minHeight: '100vh',
+      }}
+    >
+      <Container maxWidth="xl">
         {/* Header */}
-        <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ md: 'flex-end' }} spacing={2} sx={{ mb: 4 }}>
+        <Stack direction={{ xs: 'column', md: 'row' }} justifyContent="space-between" alignItems={{ md: 'center' }} spacing={2} sx={{ mb: 2 }}>
           <Box>
-            <Typography variant="h4" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>
+            <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', lineHeight: 1.2 }}>
               Monthly Budget
             </Typography>
-            <Typography variant="body1" color="text.secondary">
-              Track your monthly budget and expenses checklist
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
+              Track your monthly budget and expenses checklist.
             </Typography>
           </Box>
           
           <Stack direction="row" spacing={2} alignItems="center">
             <FormControl size="small" sx={{ minWidth: 120 }}>
-              <InputLabel>Month</InputLabel>
-              <Select value={selectedMonth} label="Month" onChange={(e) => setSelectedMonth(Number(e.target.value))}>
+              <InputLabel id="budget-month-label">Month</InputLabel>
+              <Select
+                labelId="budget-month-label"
+                value={selectedMonth}
+                label="Month"
+                input={<OutlinedInput label="Month" sx={{ borderRadius: 1.5, fontSize: '0.85rem' }} />}
+                onChange={(e) => setSelectedMonth(Number(e.target.value))}
+              >
                 {MONTH_NAMES.map((name, i) => <MenuItem key={i} value={i + 1}>{name}</MenuItem>)}
               </Select>
             </FormControl>
@@ -328,199 +357,313 @@ export default function MonthlyPlannerPage() {
               type="number"
               value={selectedYear}
               onChange={(e) => setSelectedYear(Number(e.target.value))}
-              sx={{ width: 100 }}
+              sx={{ width: 100, '& .MuiOutlinedInput-root': { borderRadius: 1.5, fontSize: '0.85rem' } }}
             />
-            <Button variant="outlined" startIcon={<Settings />} onClick={() => navigate('/settings?tab=categories')}>
+            <Button
+              variant="outlined"
+              color="inherit"
+              size="small"
+              startIcon={<Settings />}
+              onClick={() => navigate('/settings?tab=categories')}
+              sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+            >
               Categories
             </Button>
           </Stack>
         </Stack>
 
-        {/* Overview Cards */}
-        <Grid container spacing={3} sx={{ mb: 4 }}>
-          <Grid size={{ xs: 12, md: 3 }}>
-            <Card>
-              <CardContent>
-                <Stack direction="row" justifyContent="space-between" alignItems="center">
-                  <Typography variant="overline" color="text.secondary">Current Salary</Typography>
-                  <Typography variant="h6" sx={{ color: 'primary.main', fontWeight: 600 }}>
-                    {formatCurrency(summary?.salary || 0)}
-                  </Typography>
-                </Stack>
+        {/* ── Summary Card: Prominent Portfolio Metrics ────────────────────────── */}
+        <Card variant="outlined" sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none', mb: 2 }}>
+          <Grid container>
+            {/* Block 1: Current Salary (Interactive) */}
+            <Grid size={{ xs: 6, md: 3 }} sx={{
+              p: 2.5,
+              borderRight: '1px solid',
+              borderRightColor: 'divider',
+              borderBottom: { xs: '1px solid', md: 'none' },
+              borderBottomColor: { xs: 'divider', md: 'transparent' },
+            }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Current Salary
+              </Typography>
+              {isEditingSalary ? (
                 <TextField
-                  fullWidth
-                  required
-                  variant="standard"
+                  size="small"
                   type="number"
-                  placeholder="Enter amount..."
-                  value={summary?.salary || 0}
-                  onChange={(e) => setSummary(s => s ? { ...s, salary: parseFloat(e.target.value) || 0 } : null)}
-                  onBlur={(e) => handleUpdateSalary(e.target.value)}
-                  slotProps={{ input: { style: { fontSize: '1.2rem', fontWeight: 700, textAlign: 'left' } } }}
+                  autoFocus
+                  value={salaryInputVal}
+                  onChange={(e) => setSalaryInputVal(e.target.value)}
+                  onBlur={handleSaveSalary}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') handleSaveSalary();
+                    if (e.key === 'Escape') setIsEditingSalary(false);
+                  }}
+                  sx={{
+                    width: '100%',
+                    '& .MuiOutlinedInput-root': { borderRadius: 1.5, fontSize: '1rem', fontWeight: 700 }
+                  }}
                 />
-                <Typography variant="caption" color="text.secondary">Net monthly income (auto-formatted above)</Typography>
-              </CardContent>
-            </Card>
+              ) : (
+                <Box
+                  sx={{ display: 'flex', alignItems: 'center', gap: 1, cursor: 'pointer' }}
+                  onClick={() => { setSalaryInputVal(String(summary?.salary || 0)); setIsEditingSalary(true); }}
+                >
+                  <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'primary.main', fontSize: '1.3rem' }}>
+                    {formatCompactRupees(summary?.salary || 0)}
+                  </Typography>
+                  <Edit sx={{ fontSize: 16, color: 'text.secondary', opacity: 0.6, '&:hover': { opacity: 1 } }} />
+                </Box>
+              )}
+            </Grid>
+
+            {/* Block 2: Total Spending */}
+            <Grid size={{ xs: 6, md: 3 }} sx={{
+              p: 2.5,
+              borderRight: { xs: 'none', md: '1px solid' },
+              borderRightColor: { xs: 'transparent', md: 'divider' },
+              borderBottom: { xs: '1px solid', md: 'none' },
+              borderBottomColor: { xs: 'divider', md: 'transparent' },
+            }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Total Spending
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'error.main', fontSize: '1.3rem' }}>
+                {formatCompactRupees(totals.totalSpending)}
+              </Typography>
+            </Grid>
+
+            {/* Block 3: Total Saving */}
+            <Grid size={{ xs: 6, md: 3 }} sx={{
+              p: 2.5,
+              borderRight: '1px solid',
+              borderRightColor: 'divider',
+            }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Total Saving
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'success.main', fontSize: '1.3rem' }}>
+                {formatCompactRupees(totals.totalSaving)}
+              </Typography>
+            </Grid>
+
+            {/* Block 4: Remaining Balance */}
+            <Grid size={{ xs: 6, md: 3 }} sx={{ p: 2.5 }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Remaining Balance
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: totals.balance >= 0 ? 'primary.main' : 'error.main', fontSize: '1.3rem' }}>
+                {formatCompactRupees(totals.balance)}
+              </Typography>
+            </Grid>
           </Grid>
-          <Grid size={{ xs: 12, md: 3 }}>
-            <Card>
-              <CardContent>
-                <Typography variant="overline" color="text.secondary">Total Spending</Typography>
-                <Typography variant="h5" sx={{ fontWeight: 700, color: 'error.main' }}>
-                  {formatCurrency(totals.totalSpending)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">Sum of all spending items</Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size={{ xs: 12, md: 3 }}>
-            <Card>
-              <CardContent>
-                <Typography variant="overline" color="text.secondary">Total Saving</Typography>
-                <Typography variant="h5" sx={{ fontWeight: 700, color: 'success.main' }}>
-                  {formatCurrency(totals.totalSaving)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">Investments and savings</Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-          <Grid size={{ xs: 12, md: 3 }}>
-            <Card>
-              <CardContent>
-                <Typography variant="overline" color="text.secondary">Remaining Balance</Typography>
-                <Typography variant="h5" sx={{ fontWeight: 700, color: totals.balance >= 0 ? 'primary.main' : 'error.main' }}>
-                  {formatCurrency(totals.balance)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">Unallocated funds</Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        </Grid>
+        </Card>
 
         {/* Tabs for View */}
-        <Tabs value={activeTab} onChange={(_, v) => setActiveTab(v)} sx={{ mb: 3 }}>
-          <Tab label="Checklist" />
-          <Tab label="Visuals" />
-        </Tabs>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
+          <Tabs
+            value={activeTab}
+            onChange={(_, v) => setActiveTab(v)}
+            sx={{
+              minHeight: 36,
+              '& .MuiTab-root': {
+                fontFamily: '"Space Grotesk", sans-serif',
+                fontWeight: 600,
+                fontSize: '0.875rem',
+                textTransform: 'none',
+                minHeight: 36,
+                px: 0,
+                mr: 3,
+                py: 0.5,
+              },
+            }}
+          >
+            <Tab label="Checklist" />
+            <Tab label="Visuals" />
+          </Tabs>
+        </Box>
 
         {activeTab === 0 && (
-          <Card>
-            <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: 1, borderColor: 'divider' }}>
-              <Typography variant="h6" sx={{ fontWeight: 600 }}>Expense Checklist</Typography>
-              <Stack direction="row" spacing={1}>
-                <Button size="small" variant="outlined" startIcon={<Sync />} onClick={handleSync}>Sync Previous</Button>
-                <Button size="small" variant="outlined" color="warning" startIcon={<RotateCcw />} onClick={handleReset}>Reset All</Button>
-                <Button size="small" variant="contained" startIcon={<Plus />} onClick={openAddExpense}>Add Item</Button>
-              </Stack>
-            </Box>
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell padding="checkbox">Status</TableCell>
-                    <TableCell>Name</TableCell>
-                    <TableCell>Type</TableCell>
-                    <TableCell>Category</TableCell>
-                    <TableCell align="right">Amount</TableCell>
-                    <TableCell align="center">Recurring</TableCell>
-                    <TableCell align="right">Actions</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {expenses.length === 0 ? (
-                    <TableRow><TableCell colSpan={7} align="center" sx={{ py: 4 }}>No items found for this month.</TableCell></TableRow>
-                  ) : (
-                    expenses.map((exp) => (
-                      <TableRow
-                        key={exp.id}
-                        hover
-                        sx={{
-                          opacity: exp.status === 'settled' ? 0.4 : 1,
-                          transition: 'opacity 0.3s ease',
-                        }}
-                      >
-                        <TableCell padding="checkbox">
-                          <Checkbox
-                            checked={exp.status === 'settled'}
-                            onChange={() => handleToggleStatus(exp)}
-                          />
-                        </TableCell>
-                        <TableCell>{exp.name}</TableCell>
-                        <TableCell>
-                          <Chip label={exp.category_l1 === 'spending' ? 'Spending' : 'Saving'} size="small" color={exp.category_l1 === 'spending' ? 'error' : 'success'} variant="outlined" />
-                        </TableCell>
-                        <TableCell>{exp.category_l2}</TableCell>
-                        <TableCell align="right" sx={{ fontWeight: 600 }}>{formatCurrency(exp.amount)}</TableCell>
-                        <TableCell align="center">
-                          {exp.is_recurring ? <Typography color="primary" variant="body2">Yes</Typography> : '-'}
-                        </TableCell>
-                        <TableCell align="right">
-                          <IconButton size="small" onClick={() => openEditExpense(exp)}><Edit sx={{ fontSize: 18 }} /></IconButton>
-                          <IconButton size="small" color="error" onClick={() => handleDeleteExpense(exp.id)}><Trash2 sx={{ fontSize: 18 }} /></IconButton>
+          <>
+            {/* Checklist Toolbar Card */}
+            <Card variant="outlined" sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none', px: 2, py: 1.25, mb: 2 }}>
+              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5, justifyContent: 'space-between', alignItems: 'center' }}>
+                <Typography variant="body2" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>
+                  Expense Checklist
+                </Typography>
+                <Stack direction="row" spacing={1.5}>
+                  <Button
+                    variant="outlined"
+                    color="inherit"
+                    size="small"
+                    startIcon={<Sync />}
+                    onClick={handleSync}
+                    sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+                  >
+                    Sync Previous
+                  </Button>
+                  <Button
+                    variant="outlined"
+                    color="warning"
+                    size="small"
+                    startIcon={<RotateCcw />}
+                    onClick={handleReset}
+                    sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+                  >
+                    Reset All
+                  </Button>
+                  <Button
+                    variant="contained"
+                    color="primary"
+                    size="small"
+                    startIcon={<Plus />}
+                    onClick={openAddExpense}
+                    sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+                  >
+                    Add Item
+                  </Button>
+                </Stack>
+              </Box>
+            </Card>
+
+            {/* Checklist Table Card */}
+            <Card variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden', border: '1px solid', borderColor: 'divider', boxShadow: 'none', mb: 2 }}>
+              <TableContainer component={Paper} elevation={0} sx={{ borderRadius: 0, bgcolor: 'transparent' }}>
+                <Table size="small">
+                  <TableHead sx={{ bgcolor: (theme) => theme.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.5)' : '#f1f5f9' }}>
+                    <TableRow>
+                      <TableCell padding="checkbox" sx={{ pl: 3 }}>Status</TableCell>
+                      <TableCell sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Name</TableCell>
+                      <TableCell sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Type</TableCell>
+                      <TableCell sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Category</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Amount</TableCell>
+                      <TableCell align="center" sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Recurring</TableCell>
+                      <TableCell align="right" sx={{ pr: 3, fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Actions</TableCell>
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {expenses.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={7} align="center" sx={{ py: 4, color: 'text.secondary' }}>
+                          No items found for this month.
                         </TableCell>
                       </TableRow>
-                    ))
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
-          </Card>
+                    ) : (
+                      expenses.map((exp, idx) => (
+                        <TableRow
+                          key={exp.id}
+                          hover
+                          sx={{
+                            opacity: exp.status === 'settled' ? 0.45 : 1,
+                            transition: 'opacity 0.2s ease',
+                            '& td': { py: 1 },
+                            bgcolor: idx % 2 === 0
+                              ? 'transparent'
+                              : (theme) => theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.018)' : 'rgba(0,0,0,0.018)',
+                            '&:hover': { bgcolor: 'action.hover' },
+                          }}
+                        >
+                          <TableCell padding="checkbox" sx={{ pl: 3 }}>
+                            <Checkbox
+                              checked={exp.status === 'settled'}
+                              onChange={() => handleToggleStatus(exp)}
+                              size="small"
+                            />
+                          </TableCell>
+                          <TableCell sx={{ fontWeight: 600 }}>{exp.name}</TableCell>
+                          <TableCell>
+                            <Chip
+                              label={exp.category_l1 === 'spending' ? 'Spending' : 'Saving'}
+                              size="small"
+                              color={exp.category_l1 === 'spending' ? 'error' : 'success'}
+                              variant="outlined"
+                              sx={{ fontWeight: 700, fontSize: '0.68rem', height: 20 }}
+                            />
+                          </TableCell>
+                          <TableCell>{exp.category_l2}</TableCell>
+                          <TableCell align="right" sx={{ fontWeight: 700 }}>{formatCurrency(exp.amount)}</TableCell>
+                          <TableCell align="center">
+                            {exp.is_recurring ? <Typography color="primary.main" variant="body2" sx={{ fontWeight: 600 }}>Yes</Typography> : '-'}
+                          </TableCell>
+                          <TableCell align="right" sx={{ pr: 3, whiteSpace: 'nowrap' }}>
+                            <Tooltip title="Edit">
+                              <IconButton size="small" color="secondary" onClick={() => openEditExpense(exp)}>
+                                <Edit sx={{ fontSize: 18 }} />
+                              </IconButton>
+                            </Tooltip>
+                            <Tooltip title="Delete">
+                              <IconButton size="small" color="error" onClick={() => handleDeleteExpense(exp.id)}>
+                                <Trash2 sx={{ fontSize: 18 }} />
+                              </IconButton>
+                            </Tooltip>
+                          </TableCell>
+                        </TableRow>
+                      ))
+                    )}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            </Card>
+          </>
         )}
 
         {activeTab === 1 && (
           <Grid container spacing={3}>
             <Grid size={{ xs: 12, md: 6 }}>
-              <Card sx={{ height: 400 }}>
-                <CardContent sx={{ height: '100%' }}>
-                  <Typography variant="h6" gutterBottom>Allocation Type</Typography>
-                  <ResponsiveContainer width="100%" height="90%">
-                      <PieChart>
-                        <Pie
-                          data={chartDataL1}
-                          cx="50%"
-                          cy="50%"
-                          innerRadius={60}
-                          outerRadius={100}
-                          paddingAngle={5}
-                          dataKey="value"
-                          labelLine={false}
-                          label={renderCustomizedLabel}
-                        >
-                          {chartDataL1.map((_, index) => (
-                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                          ))}
-                        </Pie>
-                        <RechartsTooltip content={<CustomTooltip />} />
-                        <Legend />
-                      </PieChart>
+              <Card variant="outlined" sx={{ height: 400, borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none' }}>
+                <CardContent sx={{ height: '100%', p: 3 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary', mb: 2 }}>
+                    Allocation Type
+                  </Typography>
+                  <ResponsiveContainer width="100%" height="85%">
+                    <PieChart>
+                      <Pie
+                        data={chartDataL1}
+                        cx="50%"
+                        cy="50%"
+                        innerRadius={60}
+                        outerRadius={90}
+                        paddingAngle={5}
+                        dataKey="value"
+                        labelLine={false}
+                        label={renderCustomizedLabel}
+                      >
+                        {chartDataL1.map((_, index) => (
+                          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <RechartsTooltip content={<CustomTooltip />} />
+                      <Legend />
+                    </PieChart>
                   </ResponsiveContainer>
                 </CardContent>
               </Card>
             </Grid>
             <Grid size={{ xs: 12, md: 6 }}>
-              <Card sx={{ height: 400 }}>
-                <CardContent sx={{ height: '100%' }}>
-                  <Typography variant="h6" gutterBottom>Category Breakdown</Typography>
-                  <ResponsiveContainer width="100%" height="90%">
-                      <PieChart>
-                        <Pie
-                          data={chartDataL2}
-                          cx="50%"
-                          cy="50%"
-                          innerRadius={60}
-                          outerRadius={100}
-                          paddingAngle={2}
-                          dataKey="value"
-                          labelLine={false}
-                          label={renderCustomizedLabel}
-                        >
-                          {chartDataL2.map((_, index) => (
-                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                          ))}
-                        </Pie>
-                        <RechartsTooltip content={<CustomTooltip />} />
-                        <Legend />
-                      </PieChart>
+              <Card variant="outlined" sx={{ height: 400, borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none' }}>
+                <CardContent sx={{ height: '100%', p: 3 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary', mb: 2 }}>
+                    Category Breakdown
+                  </Typography>
+                  <ResponsiveContainer width="100%" height="85%">
+                    <PieChart>
+                      <Pie
+                        data={chartDataL2}
+                        cx="50%"
+                        cy="50%"
+                        innerRadius={60}
+                        outerRadius={90}
+                        paddingAngle={2}
+                        dataKey="value"
+                        labelLine={false}
+                        label={renderCustomizedLabel}
+                      >
+                        {chartDataL2.map((_, index) => (
+                          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <RechartsTooltip content={<CustomTooltip />} />
+                      <Legend />
+                    </PieChart>
                   </ResponsiveContainer>
                 </CardContent>
               </Card>
@@ -528,13 +671,13 @@ export default function MonthlyPlannerPage() {
           </Grid>
         )}
 
-
-
         {/* --- Expense Form Modal --- */}
-        <Dialog open={isExpenseModalOpen} onClose={() => setIsExpenseModalOpen(false)} maxWidth="xs" fullWidth>
-          <DialogTitle>{editingExpense ? 'Edit Expense' : 'Add Expense'}</DialogTitle>
+        <Dialog open={isExpenseModalOpen} onClose={() => setIsExpenseModalOpen(false)} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>
+            {editingExpense ? 'Edit Expense' : 'Add Expense'}
+          </DialogTitle>
           <DialogContent>
-            <Stack spacing={2} sx={{ pt: 1 }}>
+            <Stack spacing={2.5} sx={{ pt: 1.5 }}>
               <TextField 
                 fullWidth label="Name" required
                 value={expenseForm.name} 
@@ -546,8 +689,9 @@ export default function MonthlyPlannerPage() {
                 onChange={(e) => setExpenseForm({ ...expenseForm, amount: parseFloat(e.target.value) || 0 })} 
               />
               <FormControl fullWidth required>
-                <InputLabel>Type</InputLabel>
+                <InputLabel id="expense-type-label">Type</InputLabel>
                 <Select
+                  labelId="expense-type-label"
                   value={expenseForm.category_l1}
                   label="Type"
                   onChange={(e) => {
@@ -565,8 +709,9 @@ export default function MonthlyPlannerPage() {
                 </Select>
               </FormControl>
               <FormControl fullWidth>
-                <InputLabel>Category (Optional)</InputLabel>
+                <InputLabel id="expense-category-label">Category (Optional)</InputLabel>
                 <Select
+                  labelId="expense-category-label"
                   value={expenseForm.category_l2}
                   label="Category (Optional)"
                   onChange={(e) => setExpenseForm({ ...expenseForm, category_l2: e.target.value })}
@@ -586,24 +731,24 @@ export default function MonthlyPlannerPage() {
                   checked={expenseForm.is_recurring} 
                   onChange={(e) => setExpenseForm({ ...expenseForm, is_recurring: e.target.checked })} 
                 />
-                <Typography>Recurring every month</Typography>
+                <Typography variant="body2">Recurring every month</Typography>
               </Stack>
             </Stack>
           </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setIsExpenseModalOpen(false)}>Cancel</Button>
-            <Button onClick={handleSaveExpense} variant="contained">Save</Button>
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsExpenseModalOpen(false)} variant="text" color="inherit">Cancel</Button>
+            <Button onClick={handleSaveExpense} variant="contained" color="primary">Save</Button>
           </DialogActions>
         </Dialog>
 
         {/* --- Confirm Dialog --- */}
-        <Dialog open={confirmDialog.open} onClose={closeConfirm} maxWidth="xs" fullWidth>
-          <DialogTitle sx={{ fontWeight: 700 }}>{confirmDialog.title}</DialogTitle>
+        <Dialog open={confirmDialog.open} onClose={closeConfirm} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>{confirmDialog.title}</DialogTitle>
           <DialogContent>
-            <Typography>{confirmDialog.message}</Typography>
+            <Typography variant="body2">{confirmDialog.message}</Typography>
           </DialogContent>
-          <DialogActions>
-            <Button onClick={closeConfirm}>Cancel</Button>
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={closeConfirm} variant="outlined" color="inherit">Cancel</Button>
             <Button
               variant="contained"
               color="error"

--- a/keys-personal-assist-ui/src/pages/SavingsFundSegregatorPage.tsx
+++ b/keys-personal-assist-ui/src/pages/SavingsFundSegregatorPage.tsx
@@ -26,6 +26,8 @@ import {
   Chip,
   LinearProgress,
   Tooltip as MuiTooltip,
+  Paper,
+  OutlinedInput,
 } from '@mui/material';
 import { Grid } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
@@ -33,9 +35,6 @@ import {
   Add as Plus,
   Edit,
   Delete as Trash2,
-  AccountBalance,
-  AccountBalanceWallet,
-  FolderShared,
   SwapHoriz,
   ArrowUpward,
   ArrowDownward,
@@ -50,7 +49,7 @@ import type {
   SavingsBucketResponse,
   SavingsBucketTransactionResponse,
 } from '@/types/api';
-import { formatCurrency } from '@/utils/formatters';
+import { formatCurrency, formatCompactRupees } from '@/utils/formatters';
 
 // Colors for the donut chart
 const COLORS = ['#3b82f6', '#0ea5e9', '#10b981', '#f59e0b', '#8b5cf6', '#06b6d4', '#6366f1', '#ef4444'];
@@ -320,29 +319,45 @@ export default function SavingsFundSegregatorPage() {
   };
 
   return (
-    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default', py: 6 }}>
+    <Box
+      sx={{
+        flexGrow: 1,
+        bgcolor: 'background.default',
+        py: 2.5,
+        px: { xs: 2, md: 4 },
+        backgroundImage: (theme) =>
+          theme.palette.mode === 'dark'
+            ? 'radial-gradient(circle at 10% 20%, rgba(30, 41, 59, 0.4) 0%, rgba(17, 24, 39, 0.95) 90%)'
+            : 'none',
+        transition: 'background-color 0.3s ease',
+        minHeight: '100vh',
+      }}
+    >
       <Container maxWidth="xl">
-        {isLoading && <LinearProgress sx={{ mb: 3, borderRadius: 1 }} />}
+        {isLoading && <LinearProgress sx={{ mb: 2, borderRadius: 1 }} />}
+
         {/* Header Block */}
-        <Box sx={{ mb: 6, display: 'flex', flexDirection: { xs: 'column', md: 'row' }, justifyContent: 'space-between', alignItems: { xs: 'flex-start', md: 'center' }, gap: 3 }}>
+        <Box sx={{ mb: 2, display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', alignItems: { xs: 'flex-start', sm: 'center' }, gap: 2 }}>
           <Box>
             <Typography
-              variant="h3"
-              sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', mb: 1, background: 'linear-gradient(135deg, #8b5cf6 0%, #6366f1 100%)', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}
+              variant="h5"
+              sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', lineHeight: 1.2 }}
             >
               Savings Envelopes
             </Typography>
-            <Typography variant="body1" color="text.secondary">
-              Partition and track allocations in your savings accounts for medical, LIC, targets, and goals.
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
+              Partition and track allocations in your savings accounts for medical, insurance, and goals.
             </Typography>
           </Box>
 
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-            <FormControl sx={{ minWidth: 240 }} size="small">
-              <InputLabel>Bank Account</InputLabel>
+            <FormControl sx={{ minWidth: 200 }} size="small">
+              <InputLabel id="bank-account-select-label">Bank Account</InputLabel>
               <Select
+                labelId="bank-account-select-label"
                 value={selectedAccountId}
                 label="Bank Account"
+                input={<OutlinedInput label="Bank Account" sx={{ borderRadius: 1.5, fontSize: '0.85rem' }} />}
                 onChange={(e) => {
                   setSelectedAccountId(e.target.value);
                   setPage(0);
@@ -367,82 +382,60 @@ export default function SavingsFundSegregatorPage() {
           </Box>
         </Box>
 
-        {/* ── Metric Cards ── */}
-        <Grid container spacing={3} sx={{ mb: 6 }}>
-          {/* Card 1: Total Savings */}
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ height: '100%', borderRadius: 3, boxShadow: 3, background: 'linear-gradient(135deg, #f3e8ff 0%, #e9d5ff 100%)', color: '#6b21a8' }}>
-              <CardContent sx={{ p: 4, display: 'flex', alignItems: 'center', gap: 3 }}>
-                <Box sx={{ width: 56, height: 56, borderRadius: 2, bgcolor: 'rgba(107, 33, 168, 0.1)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                  <AccountBalance sx={{ fontSize: 32 }} />
-                </Box>
-                <Box>
-                  <Typography variant="body2" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, opacity: 0.8 }}>
-                    Total Savings
-                  </Typography>
-                  <Typography variant="h4" sx={{ fontWeight: 700, my: 0.5 }}>
-                    {formatCurrency(totalSavings)}
-                  </Typography>
-                  <Typography variant="caption" sx={{ opacity: 0.7 }}>
-                    Sum of all envelopes
-                  </Typography>
-                </Box>
-              </CardContent>
-            </Card>
-          </Grid>
+        {/* ── Summary Card: Prominent Portfolio Metrics ────────────────────────── */}
+        <Card variant="outlined" sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none', mb: 2 }}>
+          <Grid container>
+            {/* Block 1: Total Savings */}
+            <Grid size={{ xs: 12, md: 4 }} sx={{
+              p: 2.5,
+              borderRight: { xs: 'none', md: '1px solid' },
+              borderRightColor: { xs: 'transparent', md: 'divider' },
+              borderBottom: { xs: '1px solid', md: 'none' },
+              borderBottomColor: { xs: 'divider', md: 'transparent' },
+            }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Total Savings
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'text.primary', fontSize: '1.3rem' }}>
+                {formatCompactRupees(totalSavings)}
+              </Typography>
+            </Grid>
 
-          {/* Card 2: Allocated Funds */}
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ height: '100%', borderRadius: 3, boxShadow: 3, background: 'linear-gradient(135deg, #e0f2fe 0%, #bae6fd 100%)', color: '#0369a1' }}>
-              <CardContent sx={{ p: 4, display: 'flex', alignItems: 'center', gap: 3 }}>
-                <Box sx={{ width: 56, height: 56, borderRadius: 2, bgcolor: 'rgba(3, 105, 161, 0.1)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                  <FolderShared sx={{ fontSize: 32 }} />
-                </Box>
-                <Box>
-                  <Typography variant="body2" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, opacity: 0.8 }}>
-                    Allocated Envelopes
-                  </Typography>
-                  <Typography variant="h4" sx={{ fontWeight: 700, my: 0.5 }}>
-                    {formatCurrency(allocatedFunds)}
-                  </Typography>
-                  <Typography variant="caption" sx={{ opacity: 0.7 }}>
-                    LIC, Medical, Targets
-                  </Typography>
-                </Box>
-              </CardContent>
-            </Card>
-          </Grid>
+            {/* Block 2: Allocated Envelopes */}
+            <Grid size={{ xs: 12, md: 4 }} sx={{
+              p: 2.5,
+              borderRight: { xs: 'none', md: '1px solid' },
+              borderRightColor: { xs: 'transparent', md: 'divider' },
+              borderBottom: { xs: '1px solid', md: 'none' },
+              borderBottomColor: { xs: 'divider', md: 'transparent' },
+            }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Allocated Envelopes
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'primary.main', fontSize: '1.3rem' }}>
+                {formatCompactRupees(allocatedFunds)}
+              </Typography>
+            </Grid>
 
-          {/* Card 3: Savings (Unallocated Pool) */}
-          <Grid size={{ xs: 12, md: 4 }}>
-            <Card sx={{ height: '100%', borderRadius: 3, boxShadow: 3, background: 'linear-gradient(135deg, #d1fae5 0%, #a7f3d0 100%)', color: '#065f46' }}>
-              <CardContent sx={{ p: 4, display: 'flex', alignItems: 'center', gap: 3 }}>
-                <Box sx={{ width: 56, height: 56, borderRadius: 2, bgcolor: 'rgba(6, 95, 70, 0.1)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                  <AccountBalanceWallet sx={{ fontSize: 32 }} />
-                </Box>
-                <Box>
-                  <Typography variant="body2" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.5, opacity: 0.8 }}>
-                    Free Savings (Unallocated)
-                  </Typography>
-                  <Typography variant="h4" sx={{ fontWeight: 700, my: 0.5 }}>
-                    {formatCurrency(unallocatedSavings)}
-                  </Typography>
-                  <Typography variant="caption" sx={{ opacity: 0.7 }}>
-                    Primary cash pool
-                  </Typography>
-                </Box>
-              </CardContent>
-            </Card>
+            {/* Block 3: Free Savings */}
+            <Grid size={{ xs: 12, md: 4 }} sx={{ p: 2.5 }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Free Savings (Unallocated)
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'success.main', fontSize: '1.3rem' }}>
+                {formatCompactRupees(unallocatedSavings)}
+              </Typography>
+            </Grid>
           </Grid>
-        </Grid>
+        </Card>
 
         {/* ── Main Layout: Visual Chart & Bucket List ── */}
-        <Grid container spacing={4} sx={{ mb: 6 }}>
+        <Grid container spacing={3} sx={{ mb: 2 }}>
           {/* Visual Donut Chart */}
           <Grid size={{ xs: 12, lg: 4 }}>
-            <Card sx={{ height: '100%', borderRadius: 3, boxShadow: 2 }}>
-              <CardContent sx={{ p: 4, display: 'flex', flexDirection: 'column', height: '100%' }}>
-                <Typography variant="h6" sx={{ fontWeight: 700, mb: 3 }}>
+            <Card variant="outlined" sx={{ height: '100%', borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none' }}>
+              <CardContent sx={{ p: 3, display: 'flex', flexDirection: 'column', height: '100%' }}>
+                <Typography variant="body2" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary', mb: 2 }}>
                   Allocation Split
                 </Typography>
                 {chartData.length === 0 ? (
@@ -475,7 +468,7 @@ export default function SavingsFundSegregatorPage() {
                         const pct = ((entry.value / totalSavings) * 100).toFixed(1);
                         return (
                           <Box key={entry.name} sx={{ display: 'flex', alignItems: 'center', gap: 0.75 }}>
-                            <Box sx={{ width: 10, height: 10, borderRadius: '50%', bgcolor: COLORS[idx % COLORS.length] }} />
+                            <Box sx={{ width: 8, height: 8, borderRadius: '50%', bgcolor: COLORS[idx % COLORS.length] }} />
                             <Typography variant="caption" sx={{ fontWeight: 600 }}>
                               {entry.name} ({pct}%)
                             </Typography>
@@ -491,17 +484,31 @@ export default function SavingsFundSegregatorPage() {
 
           {/* Envelopes list */}
           <Grid size={{ xs: 12, lg: 8 }}>
-            <Card sx={{ height: '100%', borderRadius: 3, boxShadow: 2 }}>
-              <CardContent sx={{ p: 4 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 4 }}>
-                  <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            <Card variant="outlined" sx={{ height: '100%', borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none' }}>
+              <CardContent sx={{ p: 3 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 3 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>
                     My Envelopes
                   </Typography>
                   <Box sx={{ display: 'flex', gap: 1.5 }}>
-                    <Button variant="outlined" startIcon={<Plus />} size="small" onClick={() => handleOpenBucketModal()} sx={{ borderRadius: 2 }}>
+                    <Button
+                      variant="outlined"
+                      color="inherit"
+                      size="small"
+                      startIcon={<Plus />}
+                      onClick={() => handleOpenBucketModal()}
+                      sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+                    >
                       Create Bucket
                     </Button>
-                    <Button variant="contained" startIcon={<SwapHoriz />} size="small" onClick={() => handleOpenTxModal('allocate')} sx={{ borderRadius: 2, background: 'linear-gradient(135deg, #ec4899 0%, #db2777 100%)', '&:hover': { background: 'linear-gradient(135deg, #db2777 0%, #be185d 100%)' } }}>
+                    <Button
+                      variant="contained"
+                      color="primary"
+                      size="small"
+                      startIcon={<SwapHoriz />}
+                      onClick={() => handleOpenTxModal('allocate')}
+                      sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+                    >
                       Move Money
                     </Button>
                   </Box>
@@ -514,52 +521,56 @@ export default function SavingsFundSegregatorPage() {
 
                     return (
                       <Grid size={{ xs: 12, sm: 6 }} key={b.id}>
-                        <Card variant="outlined" sx={{ borderRadius: 2, p: 2.5, position: 'relative', borderLeft: `5px solid ${isRoot ? '#10b981' : '#6366f1'}` }}>
+                        <Card variant="outlined" sx={{ borderRadius: 2, p: 2, position: 'relative', borderLeft: `4px solid ${isRoot ? '#10b981' : '#6366f1'}`, boxShadow: 'none' }}>
                           <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', mb: 1 }}>
                             <Box>
-                              <Typography variant="subtitle1" sx={{ fontWeight: 700 }}>
+                              <Typography variant="body2" sx={{ fontWeight: 700 }}>
                                 {b.name}
                               </Typography>
-                              <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+                              <Typography variant="caption" color="text.secondary" sx={{ mt: 0.5, display: 'block' }}>
                                 {isRoot ? 'General Cash Pool' : 'Special Bucket'}
                               </Typography>
                             </Box>
                             
                             {!isRoot && (
                               <Box sx={{ display: 'flex', gap: 0.5 }}>
-                                <IconButton size="small" color="primary" onClick={() => handleOpenBucketModal(b)}>
-                                  <Edit fontSize="small" />
-                                </IconButton>
-                                <IconButton size="small" color="error" onClick={() => handleDeleteBucket(b.id)}>
-                                  <Trash2 fontSize="small" />
-                                </IconButton>
+                                <MuiTooltip title="Edit">
+                                  <IconButton size="small" color="secondary" onClick={() => handleOpenBucketModal(b)}>
+                                    <Edit fontSize="small" />
+                                  </IconButton>
+                                </MuiTooltip>
+                                <MuiTooltip title="Delete">
+                                  <IconButton size="small" color="error" onClick={() => handleDeleteBucket(b.id)}>
+                                    <Trash2 fontSize="small" />
+                                  </IconButton>
+                                </MuiTooltip>
                               </Box>
                             )}
                           </Box>
 
-                          <Box sx={{ my: 2 }}>
-                            <Typography variant="h5" sx={{ fontWeight: 800 }}>
+                          <Box sx={{ my: 1.5 }}>
+                            <Typography variant="h6" sx={{ fontWeight: 800, fontFamily: '"Space Grotesk", sans-serif' }}>
                               {formatCurrency(b.allocatedAmount)}
                             </Typography>
                             {b.targetAmount && (
-                              <Typography variant="caption" color="text.secondary">
+                              <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mt: 0.5 }}>
                                 Target: {formatCurrency(b.targetAmount)} ({targetPercent.toFixed(0)}%)
                               </Typography>
                             )}
                           </Box>
 
                           {b.targetAmount && (
-                            <Box sx={{ mt: 1.5 }}>
+                            <Box sx={{ mt: 1 }}>
                               <LinearProgress
                                 variant="determinate"
                                 value={targetPercent}
                                 sx={{
-                                  height: 6,
-                                  borderRadius: 3,
+                                  height: 4,
+                                  borderRadius: 2,
                                   bgcolor: 'rgba(99, 102, 241, 0.1)',
                                   '& .MuiLinearProgress-bar': {
                                     bgcolor: '#6366f1',
-                                    borderRadius: 3,
+                                    borderRadius: 2,
                                   },
                                 }}
                               />
@@ -576,147 +587,170 @@ export default function SavingsFundSegregatorPage() {
         </Grid>
 
         {/* ── Transaction Ledger Block ── */}
-        <Card sx={{ borderRadius: 3, boxShadow: 3 }}>
-          <CardContent sx={{ p: 4 }}>
-            <Box sx={{ display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', alignItems: { xs: 'flex-start', sm: 'center' }, gap: 2, mb: 4 }}>
-              <Box>
-                <Typography variant="h6" sx={{ fontWeight: 700 }}>
-                  Allocation Ledger
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Complete history of allocations, releases, deposits, and transfers.
-                </Typography>
-              </Box>
-              <Box sx={{ display: 'flex', gap: 1.5 }}>
-                <Button variant="outlined" size="small" startIcon={<ArrowUpward />} onClick={() => handleOpenTxModal('deposit')} color="success" sx={{ borderRadius: 2 }}>
-                  Deposit
-                </Button>
-                <Button variant="outlined" size="small" startIcon={<ArrowDownward />} onClick={() => handleOpenTxModal('withdraw')} color="error" sx={{ borderRadius: 2 }}>
-                  Withdrawal
-                </Button>
-              </Box>
+        <Card variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden', border: '1px solid', borderColor: 'divider', boxShadow: 'none', mb: 2 }}>
+          <Box sx={{ p: 2, display: 'flex', flexDirection: { xs: 'column', sm: 'row' }, justifyContent: 'space-between', alignItems: { xs: 'flex-start', sm: 'center' }, gap: 2, borderBottom: '1px solid', borderColor: 'divider' }}>
+            <Box>
+              <Typography variant="body2" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>
+                Allocation Ledger
+              </Typography>
+              <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
+                Complete history of allocations, releases, deposits, and transfers.
+              </Typography>
             </Box>
+            <Box sx={{ display: 'flex', gap: 1.5 }}>
+              <Button
+                variant="outlined"
+                color="success"
+                size="small"
+                startIcon={<ArrowUpward />}
+                onClick={() => handleOpenTxModal('deposit')}
+                sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+              >
+                Deposit
+              </Button>
+              <Button
+                variant="outlined"
+                color="error"
+                size="small"
+                startIcon={<ArrowDownward />}
+                onClick={() => handleOpenTxModal('withdraw')}
+                sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+              >
+                Withdraw
+              </Button>
+            </Box>
+          </Box>
 
-            <TableContainer>
-              <Table size="medium">
-                <TableHead>
-                  <TableRow sx={{ bgcolor: 'action.hover' }}>
-                    <TableCell sx={{ fontWeight: 700 }}>Date</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Type</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Source Envelope</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Destination Envelope</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }} align="right">Amount</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }}>Comment / Description</TableCell>
-                    <TableCell sx={{ fontWeight: 700 }} align="center">Actions</TableCell>
+          <TableContainer component={Paper} elevation={0} sx={{ borderRadius: 0, bgcolor: 'transparent' }}>
+            <Table size="small">
+              <TableHead sx={{ bgcolor: (theme) => theme.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.5)' : '#f1f5f9' }}>
+                <TableRow>
+                  <TableCell sx={{ pl: 3, fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Date</TableCell>
+                  <TableCell sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Type</TableCell>
+                  <TableCell sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Source Envelope</TableCell>
+                  <TableCell sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Destination Envelope</TableCell>
+                  <TableCell align="right" sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Amount</TableCell>
+                  <TableCell sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Comment</TableCell>
+                  <TableCell align="center" sx={{ pr: 3, fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Actions</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {transactions.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={7} align="center" sx={{ py: 6, color: 'text.secondary' }}>
+                      No transactions logged yet
+                    </TableCell>
                   </TableRow>
-                </TableHead>
-                <TableBody>
-                  {transactions.length === 0 ? (
-                    <TableRow>
-                      <TableCell colSpan={7} align="center" sx={{ py: 6, color: 'text.secondary' }}>
-                        No transactions logged yet
-                      </TableCell>
-                    </TableRow>
-                  ) : (
-                    transactions.map((t) => {
-                      let typeLabel = t.transactionType.toUpperCase();
-                      let typeColor: 'success' | 'error' | 'warning' | 'primary' | 'info' | 'default' = 'primary';
-                      let amountPrefix = '';
-                      let amountColor = 'text.primary';
+                ) : (
+                  transactions.map((t, idx) => {
+                    let typeLabel = t.transactionType.toUpperCase();
+                    let typeColor: 'success' | 'error' | 'warning' | 'primary' | 'info' | 'default' = 'primary';
+                    let amountPrefix = '';
+                    let amountColor = 'text.primary';
 
-                      if (t.transactionType === 'deposit') {
-                        typeColor = 'success';
-                        amountPrefix = '+';
-                        amountColor = 'success.main';
-                      } else if (t.transactionType === 'withdraw') {
-                        typeColor = 'error';
-                        amountPrefix = '-';
-                        amountColor = 'error.main';
-                      } else if (t.transactionType === 'allocate') {
-                        typeColor = 'warning';
-                        amountColor = 'text.secondary';
-                      } else if (t.transactionType === 'release') {
-                        typeColor = 'info';
-                        amountColor = 'text.secondary';
-                      }
+                    if (t.transactionType === 'deposit') {
+                      typeColor = 'success';
+                      amountPrefix = '+';
+                      amountColor = 'success.main';
+                    } else if (t.transactionType === 'withdraw') {
+                      typeColor = 'error';
+                      amountPrefix = '-';
+                      amountColor = 'error.main';
+                    } else if (t.transactionType === 'allocate') {
+                      typeColor = 'warning';
+                      amountColor = 'text.secondary';
+                    } else if (t.transactionType === 'release') {
+                      typeColor = 'info';
+                      amountColor = 'text.secondary';
+                    }
 
-                      if (t.isCancelled) {
-                        typeColor = 'default';
-                      }
+                    if (t.isCancelled) {
+                      typeColor = 'default';
+                    }
 
-                      return (
-                        <TableRow key={t.id} hover>
-                          <TableCell sx={{ fontWeight: 500, color: t.isCancelled ? 'text.disabled' : 'text.primary' }}>
-                            {new Date(t.transactionDate).toLocaleDateString('en-IN', {
-                              day: '2-digit',
-                              month: 'short',
-                              year: 'numeric',
-                              hour: '2-digit',
-                              minute: '2-digit',
-                            })}
-                          </TableCell>
-                          <TableCell>
-                            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                              <Chip label={typeLabel} size="small" color={typeColor} variant="outlined" sx={{ fontWeight: 700 }} />
-                              {t.isCancelled && (
-                                <Chip label="CANCELLED" size="small" color="error" variant="filled" sx={{ fontWeight: 700, fontSize: '0.65rem', height: 20 }} />
-                              )}
-                            </Box>
-                          </TableCell>
-                          <TableCell sx={{ fontWeight: 500, color: t.isCancelled ? 'text.disabled' : 'text.primary' }}>{getBucketNameById(t.sourceBucketId)}</TableCell>
-                          <TableCell sx={{ fontWeight: 500, color: t.isCancelled ? 'text.disabled' : 'text.primary' }}>{getBucketNameById(t.destinationBucketId)}</TableCell>
-                          <TableCell align="right" sx={{ fontWeight: 700, color: t.isCancelled ? 'text.disabled' : amountColor, textDecoration: t.isCancelled ? 'line-through' : 'none' }}>
-                            {amountPrefix}{formatCurrency(t.amount)}
-                          </TableCell>
-                          <TableCell sx={{ color: t.isCancelled ? 'text.disabled' : 'text.secondary', maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-                            <span style={{ textDecoration: t.isCancelled ? 'line-through' : 'none' }}>{t.description}</span>
+                    return (
+                      <TableRow
+                        key={t.id}
+                        sx={{
+                          '& td': { py: 1 },
+                          bgcolor: idx % 2 === 0
+                            ? 'transparent'
+                            : (theme) => theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.018)' : 'rgba(0,0,0,0.018)',
+                          '&:hover': { bgcolor: 'action.hover' },
+                        }}
+                      >
+                        <TableCell sx={{ pl: 3, fontWeight: 500, color: t.isCancelled ? 'text.disabled' : 'text.primary' }}>
+                          {new Date(t.transactionDate).toLocaleDateString('en-IN', {
+                            day: '2-digit',
+                            month: 'short',
+                            year: 'numeric',
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })}
+                        </TableCell>
+                        <TableCell>
+                          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                            <Chip label={typeLabel} size="small" color={typeColor} variant="outlined" sx={{ fontWeight: 700, fontSize: '0.68rem', height: 20 }} />
                             {t.isCancelled && (
-                              <Typography variant="caption" display="block" color="error" sx={{ fontWeight: 600 }}>
-                                Reason: {t.cancellationReason}
-                              </Typography>
+                              <Chip label="CANCELLED" size="small" color="error" variant="filled" sx={{ fontWeight: 700, fontSize: '0.625rem', height: 18 }} />
                             )}
-                          </TableCell>
-                          <TableCell align="center">
-                            {!t.isCancelled && (
+                          </Box>
+                        </TableCell>
+                        <TableCell sx={{ fontWeight: 500, color: t.isCancelled ? 'text.disabled' : 'text.primary' }}>{getBucketNameById(t.sourceBucketId)}</TableCell>
+                        <TableCell sx={{ fontWeight: 500, color: t.isCancelled ? 'text.disabled' : 'text.primary' }}>{getBucketNameById(t.destinationBucketId)}</TableCell>
+                        <TableCell align="right" sx={{ fontWeight: 700, color: t.isCancelled ? 'text.disabled' : amountColor, textDecoration: t.isCancelled ? 'line-through' : 'none' }}>
+                          {amountPrefix}{formatCurrency(t.amount)}
+                        </TableCell>
+                        <TableCell sx={{ color: t.isCancelled ? 'text.disabled' : 'text.secondary', maxWidth: 300, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                          <span style={{ textDecoration: t.isCancelled ? 'line-through' : 'none' }}>{t.description}</span>
+                          {t.isCancelled && (
+                            <Typography variant="caption" display="block" color="error" sx={{ fontWeight: 600 }}>
+                              Reason: {t.cancellationReason}
+                            </Typography>
+                          )}
+                        </TableCell>
+                        <TableCell align="center" sx={{ pr: 3 }}>
+                          {!t.isCancelled && (
+                            <MuiTooltip title="Cancel Transaction">
                               <IconButton
                                 size="small"
                                 color="error"
                                 onClick={() => handleOpenCancelModal(t)}
-                                title="Cancel Transaction"
                               >
                                 <Block fontSize="small" />
                               </IconButton>
-                            )}
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })
-                  )}
-                </TableBody>
-              </Table>
-            </TableContainer>
-            <TablePagination
-              rowsPerPageOptions={[10, 25, 50]}
-              component="div"
-              count={totalTxs}
-              rowsPerPage={rowsPerPage}
-              page={page}
-              onPageChange={(_e, newPage) => setPage(newPage)}
-              onRowsPerPageChange={(e) => {
-                setRowsPerPage(parseInt(e.target.value, 10));
-                setPage(0);
-              }}
-            />
-          </CardContent>
+                            </MuiTooltip>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+          <TablePagination
+            rowsPerPageOptions={[10, 25, 50]}
+            component="div"
+            count={totalTxs}
+            rowsPerPage={rowsPerPage}
+            page={page}
+            onPageChange={(_e, newPage) => setPage(newPage)}
+            onRowsPerPageChange={(e) => {
+              setRowsPerPage(parseInt(e.target.value, 10));
+              setPage(0);
+            }}
+            sx={{ borderTop: '1px solid', borderColor: 'divider' }}
+          />
         </Card>
 
         {/* ── Add/Edit Bucket Dialog ── */}
-        <Dialog open={isBucketModalOpen} onClose={() => setIsBucketModalOpen(false)} maxWidth="xs" fullWidth>
-          <DialogTitle sx={{ fontWeight: 700 }}>
+        <Dialog open={isBucketModalOpen} onClose={() => setIsBucketModalOpen(false)} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>
             {bucketEditId ? 'Edit Envelope Details' : 'Create New Envelope'}
           </DialogTitle>
           <DialogContent>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 2 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 1.5 }}>
               <TextField
                 fullWidth
                 label="Envelope Name"
@@ -735,22 +769,23 @@ export default function SavingsFundSegregatorPage() {
               />
             </Box>
           </DialogContent>
-          <DialogActions sx={{ px: 3, pb: 3 }}>
-            <Button onClick={() => setIsBucketModalOpen(false)}>Cancel</Button>
-            <Button onClick={handleSaveBucket} variant="contained">
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsBucketModalOpen(false)} variant="text" color="inherit">Cancel</Button>
+            <Button onClick={handleSaveBucket} variant="contained" color="primary">
               {bucketEditId ? 'Save Changes' : 'Create'}
             </Button>
           </DialogActions>
         </Dialog>
 
         {/* ── Transaction Move Money Dialog ── */}
-        <Dialog open={isTxModalOpen} onClose={() => setIsTxModalOpen(false)} maxWidth="sm" fullWidth>
-          <DialogTitle sx={{ fontWeight: 700 }}>Log Transaction Entry</DialogTitle>
+        <Dialog open={isTxModalOpen} onClose={() => setIsTxModalOpen(false)} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>Log Transaction Entry</DialogTitle>
           <DialogContent>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 2 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 1.5 }}>
               <FormControl fullWidth>
-                <InputLabel>Action Type</InputLabel>
+                <InputLabel id="tx-action-type-label">Action Type</InputLabel>
                 <Select
+                  labelId="tx-action-type-label"
                   value={txType}
                   label="Action Type"
                   onChange={(e) => {
@@ -787,8 +822,9 @@ export default function SavingsFundSegregatorPage() {
               {/* Source Selector */}
               {txType !== 'deposit' && (
                 <FormControl fullWidth>
-                  <InputLabel>Source Envelope</InputLabel>
+                  <InputLabel id="tx-source-envelope-label">Source Envelope</InputLabel>
                   <Select
+                    labelId="tx-source-envelope-label"
                     value={txSourceId}
                     label="Source Envelope"
                     onChange={(e) => setTxSourceId(e.target.value)}
@@ -807,8 +843,9 @@ export default function SavingsFundSegregatorPage() {
               {/* Destination Selector */}
               {txType !== 'withdraw' && (
                 <FormControl fullWidth>
-                  <InputLabel>Destination Envelope</InputLabel>
+                  <InputLabel id="tx-dest-envelope-label">Destination Envelope</InputLabel>
                   <Select
+                    labelId="tx-dest-envelope-label"
                     value={txDestId}
                     label="Destination Envelope"
                     onChange={(e) => setTxDestId(e.target.value)}
@@ -855,19 +892,19 @@ export default function SavingsFundSegregatorPage() {
               />
             </Box>
           </DialogContent>
-          <DialogActions sx={{ px: 3, pb: 3 }}>
-            <Button onClick={() => setIsTxModalOpen(false)}>Cancel</Button>
-            <Button onClick={handleSaveTx} variant="contained">
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsTxModalOpen(false)} variant="text" color="inherit">Cancel</Button>
+            <Button onClick={handleSaveTx} variant="contained" color="primary">
               Submit Transaction
             </Button>
           </DialogActions>
         </Dialog>
 
         {/* ── Cancel Transaction Dialog ── */}
-        <Dialog open={isCancelModalOpen} onClose={() => setIsCancelModalOpen(false)} maxWidth="xs" fullWidth>
-          <DialogTitle sx={{ fontWeight: 700 }}>Cancel Transaction</DialogTitle>
+        <Dialog open={isCancelModalOpen} onClose={() => setIsCancelModalOpen(false)} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>Cancel Transaction</DialogTitle>
           <DialogContent>
-            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 1 }}>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2.5, pt: 1.5 }}>
               <Typography variant="body2" color="text.secondary">
                 Are you sure you want to cancel this transaction? This will reverse the balance adjustments in the respective envelopes.
               </Typography>
@@ -883,8 +920,8 @@ export default function SavingsFundSegregatorPage() {
               />
             </Box>
           </DialogContent>
-          <DialogActions sx={{ px: 3, pb: 3 }}>
-            <Button onClick={() => setIsCancelModalOpen(false)}>Cancel</Button>
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsCancelModalOpen(false)} variant="text" color="inherit">Cancel</Button>
             <Button onClick={handleConfirmCancel} variant="contained" color="error" disabled={!cancelReason.trim()}>
               Confirm Cancellation
             </Button>
@@ -892,22 +929,20 @@ export default function SavingsFundSegregatorPage() {
         </Dialog>
 
         {/* ── Delete Bucket Confirmation Dialog ── */}
-        <Dialog open={isDeleteBucketModalOpen} onClose={() => setIsDeleteBucketModalOpen(false)} maxWidth="xs" fullWidth>
-          <DialogTitle sx={{ fontWeight: 700 }}>Delete Envelope</DialogTitle>
+        <Dialog open={isDeleteBucketModalOpen} onClose={() => setIsDeleteBucketModalOpen(false)} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>Delete Envelope</DialogTitle>
           <DialogContent>
             <Typography variant="body2" color="text.secondary">
               Are you sure you want to delete this envelope? Any remaining balance will be automatically refunded back to your main Savings pool.
             </Typography>
           </DialogContent>
-          <DialogActions sx={{ px: 3, pb: 3 }}>
-            <Button onClick={() => setIsDeleteBucketModalOpen(false)}>Cancel</Button>
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsDeleteBucketModalOpen(false)} variant="outlined" color="inherit">Cancel</Button>
             <Button onClick={handleConfirmDeleteBucket} variant="contained" color="error">
               Delete Envelope
             </Button>
           </DialogActions>
         </Dialog>
-
-
       </Container>
     </Box>
   );

--- a/keys-personal-assist-ui/src/pages/SpendingAccountSummaryPage.tsx
+++ b/keys-personal-assist-ui/src/pages/SpendingAccountSummaryPage.tsx
@@ -4,7 +4,6 @@ import {
   Container,
   Typography,
   Card,
-  CardContent,
   Button,
   Select,
   MenuItem,
@@ -26,17 +25,14 @@ import {
   TextField,
   OutlinedInput,
   Tooltip,
+  Paper,
+  Grid,
 } from '@mui/material';
-import { Grid } from '@mui/material';
 import {
   Add as Plus,
   Edit,
   Delete as Trash2,
   Refresh as RotateCcw,
-  TrendingDown,
-  AccountBalance,
-  CreditCard,
-  Payments,
   Settings,
 } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
@@ -49,7 +45,7 @@ import type {
   SortOrder,
   SpendingEntrySortField,
 } from '@/types/api';
-import { formatCurrency } from '@/utils/formatters';
+import { formatCurrency, formatCompactRupees } from '@/utils/formatters';
 
 type SpendingAccountEntry = SpendingAccountEntryWithCalculatedFieldsResponse;
 
@@ -334,11 +330,28 @@ export default function SpendingAccountSummaryPage() {
     align?: 'left' | 'right' | 'center';
     children: React.ReactNode;
   }) => (
-    <TableCell align={align} sortDirection={sortBy === field ? sortOrder : false}>
+    <TableCell
+      align={align}
+      sortDirection={sortBy === field ? sortOrder : false}
+      sx={{
+        pl: align === 'left' ? 3 : undefined,
+        fontWeight: 700,
+        py: 1.25,
+        fontSize: '0.78rem',
+        textTransform: 'uppercase',
+        letterSpacing: 0.5,
+        color: 'text.secondary',
+      }}
+    >
       <TableSortLabel
         active={sortBy === field}
         direction={sortBy === field ? sortOrder : 'asc'}
         onClick={() => handleSort(field)}
+        sx={{
+          '&.MuiTableSortLabel-active': {
+            color: 'text.primary',
+          },
+        }}
       >
         {children}
       </TableSortLabel>
@@ -354,211 +367,200 @@ export default function SpendingAccountSummaryPage() {
     : 'All Accounts';
 
   return (
-    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
-      <Container maxWidth="xl" sx={{ py: 4 }}>
+    <Box
+      sx={{
+        flexGrow: 1,
+        bgcolor: 'background.default',
+        py: 2.5,
+        px: { xs: 2, md: 4 },
+        backgroundImage: (theme) =>
+          theme.palette.mode === 'dark'
+            ? 'radial-gradient(circle at 10% 20%, rgba(30, 41, 59, 0.4) 0%, rgba(17, 24, 39, 0.95) 90%)'
+            : 'none',
+        transition: 'background-color 0.3s ease',
+        minHeight: '100vh',
+      }}
+    >
+      <Container maxWidth="xl">
         {/* Header */}
-        <Box sx={{ mb: 4, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+        <Box sx={{ mb: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
           <Box>
             <Typography
-              variant="h4"
-              sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', mb: 0.5 }}
+              variant="h5"
+              sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', lineHeight: 1.2 }}
             >
-              Account Balances
+              Spending Accounts
             </Typography>
-            <Typography variant="body1" color="text.secondary">
+            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
               {contextLabel} · {paginationMeta.totalElements} entries
             </Typography>
           </Box>
         </Box>
 
-        {/* ── Metric Cards ─────────────────────────────────────────────────────── */}
-        <Grid container spacing={3} sx={{ mb: 4 }}>
-          {/* Card 1 — Starting Balance */}
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <Card>
-              <CardContent>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                  <AccountBalance fontSize="small" color="success" />
-                  <Typography variant="body2" color="text.secondary">
-                    Starting Balance · filtered
-                  </Typography>
-                </Box>
-                <Typography variant="h5" sx={{ fontWeight: 700, color: 'success.main' }}>
-                  {formatCurrency(totalStartingBalance)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Initial money in accounts
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* Card 2 — Total Spent */}
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <Card>
-              <CardContent>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                  <TrendingDown fontSize="small" color="error" />
-                  <Typography variant="body2" color="text.secondary">
-                    Total Spent · filtered
-                  </Typography>
-                </Box>
-                <Typography variant="h5" sx={{ fontWeight: 700, color: 'error.main' }}>
-                  {formatCurrency(totalSpent)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Starting − cash balance
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* Card 3 — Current Cash */}
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <Card>
-              <CardContent>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                  <Payments fontSize="small" color="info" />
-                  <Typography variant="body2" color="text.secondary">
-                    Current Cash · filtered
-                  </Typography>
-                </Box>
-                <Typography variant="h5" sx={{ fontWeight: 700, color: 'info.main' }}>
-                  {formatCurrency(totalCurrentBalance)}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  Checking and cash balances
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-
-          {/* Card 4 — Credit Card Debt & Net Balance */}
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-            <Card>
-              <CardContent>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-                  <CreditCard fontSize="small" color="warning" />
-                  <Typography variant="body2" color="text.secondary">
-                    Credit Card Debt · filtered
-                  </Typography>
-                </Box>
-                <Typography variant="h5" sx={{ fontWeight: 700, color: 'warning.main' }}>
-                  {formatCurrency(totalCurrentCredit)}
-                </Typography>
-                <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 500 }}>
-                  Net Balance: {formatCurrency(totalBalanceAfterCredit)}
-                </Typography>
-              </CardContent>
-            </Card>
-          </Grid>
-        </Grid>
-
-        {/* ── Filter bar ───────────────────────────────────────────────────────── */}
-        <Card sx={{ mb: 3 }}>
-          <CardContent>
-            <Grid container spacing={2} alignItems="center">
-              {/* Account filter */}
-              <Grid size={{ xs: 12, sm: 6, md: 4 }}>
-                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                  <FormControl fullWidth size="small">
-                    <InputLabel shrink>Account</InputLabel>
-                    <Select
-                      value={filterAccount}
-                      displayEmpty
-                      input={<OutlinedInput notched label="Account" />}
-                      onChange={(e) => { setFilterAccount(e.target.value); setPage(0); }}
-                      renderValue={(v: string) => v || <em style={{ color: '#9e9e9e' }}>All Accounts</em>}
-                    >
-                      <MenuItem value="">All Accounts</MenuItem>
-                      {accounts.map((a) => (
-                        <MenuItem key={a} value={a}>{a}</MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
-                  <Tooltip title="Manage Accounts">
-                    <IconButton
-                      size="small"
-                      onClick={() => navigate('/settings?tab=accounts')}
-                      color="primary"
-                    >
-                      <Settings fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
-                </Box>
-              </Grid>
-
-              {/* Month filter */}
-              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                <FormControl fullWidth size="small">
-                  <InputLabel shrink>Month</InputLabel>
-                  <Select
-                    value={filterMonth}
-                    displayEmpty
-                    input={<OutlinedInput notched label="Month" />}
-                    onChange={(e) => { setFilterMonth(e.target.value); setPage(0); }}
-                    renderValue={(v: string) =>
-                      v !== '' ? MONTH_NAMES[parseInt(v, 10) - 1] : <em style={{ color: '#9e9e9e' }}>All Months</em>
-                    }
-                  >
-                    <MenuItem value="">All Months</MenuItem>
-                    {MONTH_NAMES.map((name, i) => (
-                      <MenuItem key={name} value={String(i + 1)}>{name}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Grid>
-
-              {/* Year filter */}
-              <Grid size={{ xs: 12, sm: 6, md: 3 }}>
-                <FormControl fullWidth size="small">
-                  <InputLabel shrink>Year</InputLabel>
-                  <Select
-                    value={filterYear}
-                    displayEmpty
-                    input={<OutlinedInput notched label="Year" />}
-                    onChange={(e) => { setFilterYear(e.target.value); setPage(0); }}
-                    renderValue={(v: string) => v || <em style={{ color: '#9e9e9e' }}>All Years</em>}
-                  >
-                    <MenuItem value="">All Years</MenuItem>
-                    {Array.from({ length: 10 }, (_, i) => String(now.getFullYear() - i)).map((y) => (
-                      <MenuItem key={y} value={y}>{y}</MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
-              </Grid>
-
-              {/* Actions */}
-              <Grid size={{ xs: 12, sm: 6, md: 2 }}>
-                <Box sx={{ display: 'flex', gap: 1 }}>
-                  <Button
-                    variant="outlined"
-                    startIcon={<RotateCcw />}
-                    onClick={resetFilters}
-                    disabled={activeFilterCount === 0}
-                    sx={{ flexShrink: 0 }}
-                  >
-                    Reset
-                  </Button>
-                  <Button
-                    variant="contained"
-                    startIcon={<Plus />}
-                    onClick={() => { setFormData(DEFAULT_FORM); setIsAddModalOpen(true); }}
-                    fullWidth
-                  >
-                    Add
-                  </Button>
-                </Box>
-              </Grid>
+        {/* ── Summary Card: Prominent Portfolio Metrics ────────────────────────── */}
+        <Card variant="outlined" sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none', mb: 2 }}>
+          <Grid container>
+            {/* Block 1: Starting Balance */}
+            <Grid size={{ xs: 6, md: 3 }} sx={{
+              p: 2.5,
+              borderRight: '1px solid',
+              borderRightColor: 'divider',
+              borderBottom: { xs: '1px solid', md: 'none' },
+              borderBottomColor: { xs: 'divider', md: 'transparent' },
+            }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Starting Balance
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'success.main', fontSize: '1.3rem' }}>
+                {formatCompactRupees(totalStartingBalance)}
+              </Typography>
             </Grid>
-          </CardContent>
+            
+            {/* Block 2: Total Spent */}
+            <Grid size={{ xs: 6, md: 3 }} sx={{
+              p: 2.5,
+              borderRight: { xs: 'none', md: '1px solid' },
+              borderRightColor: { xs: 'transparent', md: 'divider' },
+              borderBottom: { xs: '1px solid', md: 'none' },
+              borderBottomColor: { xs: 'divider', md: 'transparent' },
+            }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Total Spent
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'error.main', fontSize: '1.3rem' }}>
+                {formatCompactRupees(totalSpent)}
+              </Typography>
+            </Grid>
+            
+            {/* Block 3: Current Cash */}
+            <Grid size={{ xs: 6, md: 3 }} sx={{
+              p: 2.5,
+              borderRight: '1px solid',
+              borderRightColor: 'divider',
+            }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Current Cash
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'info.main', fontSize: '1.3rem' }}>
+                {formatCompactRupees(totalCurrentBalance)}
+              </Typography>
+            </Grid>
+            
+            {/* Block 4: Credit CC Debt & Net */}
+            <Grid size={{ xs: 6, md: 3 }} sx={{ p: 2.5 }}>
+              <Typography variant="caption" color="text.disabled" sx={{ fontWeight: 600, textTransform: 'uppercase', letterSpacing: 0.8, fontSize: '0.68rem', display: 'block', mb: 0.5 }}>
+                Credit Card Debt
+              </Typography>
+              <Typography variant="h5" sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif', color: 'warning.main', fontSize: '1.3rem', mb: 0.5 }}>
+                {formatCompactRupees(totalCurrentCredit)}
+              </Typography>
+              <Typography variant="caption" sx={{ color: 'text.secondary', fontWeight: 600 }}>
+                Net: {formatCompactRupees(totalBalanceAfterCredit)}
+              </Typography>
+            </Grid>
+          </Grid>
         </Card>
 
-        {/* ── Table ───────────────────────────────────────────────────────────── */}
-        <Card>
-          <TableContainer>
+        {/* ── Toolbar Card: Filters + Actions ─────────────────────────────────── */}
+        <Card variant="outlined" sx={{ borderRadius: 2, border: '1px solid', borderColor: 'divider', boxShadow: 'none', px: 2, py: 1.25, mb: 2 }}>
+          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1.5, justifyContent: 'space-between', alignItems: 'center' }}>
+            {/* Left: Filters */}
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5, flexGrow: 1, flexWrap: 'wrap' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                <FormControl size="small" sx={{ width: 180 }}>
+                  <InputLabel id="filter-account-label" shrink>Account</InputLabel>
+                  <Select
+                    labelId="filter-account-label"
+                    value={filterAccount}
+                    displayEmpty
+                    input={<OutlinedInput notched label="Account" sx={{ borderRadius: 1.5, fontSize: '0.85rem' }} />}
+                    onChange={(e) => { setFilterAccount(e.target.value); setPage(0); }}
+                    renderValue={(v: string) => v || <em style={{ color: '#9e9e9e' }}>All Accounts</em>}
+                  >
+                    <MenuItem value="">All Accounts</MenuItem>
+                    {accounts.map((a) => (
+                      <MenuItem key={a} value={a}>{a}</MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+                <Tooltip title="Manage Accounts">
+                  <IconButton
+                    size="small"
+                    onClick={() => navigate('/settings?tab=accounts')}
+                    color="primary"
+                  >
+                    <Settings fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              </Box>
+
+              <FormControl size="small" sx={{ width: 140 }}>
+                <InputLabel id="filter-month-label" shrink>Month</InputLabel>
+                <Select
+                  labelId="filter-month-label"
+                  value={filterMonth}
+                  displayEmpty
+                  input={<OutlinedInput notched label="Month" sx={{ borderRadius: 1.5, fontSize: '0.85rem' }} />}
+                  onChange={(e) => { setFilterMonth(e.target.value); setPage(0); }}
+                  renderValue={(v: string) =>
+                    v !== '' ? MONTH_NAMES[parseInt(v, 10) - 1] : <em style={{ color: '#9e9e9e' }}>All Months</em>
+                  }
+                >
+                  <MenuItem value="">All Months</MenuItem>
+                  {MONTH_NAMES.map((name, i) => (
+                    <MenuItem key={name} value={String(i + 1)}>{name}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <FormControl size="small" sx={{ width: 120 }}>
+                <InputLabel id="filter-year-label" shrink>Year</InputLabel>
+                <Select
+                  labelId="filter-year-label"
+                  value={filterYear}
+                  displayEmpty
+                  input={<OutlinedInput notched label="Year" sx={{ borderRadius: 1.5, fontSize: '0.85rem' }} />}
+                  onChange={(e) => { setFilterYear(e.target.value); setPage(0); }}
+                  renderValue={(v: string) => v || <em style={{ color: '#9e9e9e' }}>All Years</em>}
+                >
+                  <MenuItem value="">All Years</MenuItem>
+                  {Array.from({ length: 10 }, (_, i) => String(now.getFullYear() - i)).map((y) => (
+                    <MenuItem key={y} value={y}>{y}</MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+
+              <Button
+                variant="outlined"
+                color="inherit"
+                size="small"
+                startIcon={<RotateCcw />}
+                onClick={resetFilters}
+                disabled={activeFilterCount === 0}
+                sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem' }}
+              >
+                Reset
+              </Button>
+            </Box>
+
+            {/* Right: Add CTA */}
+            <Button
+              variant="contained"
+              color="primary"
+              startIcon={<Plus />}
+              onClick={() => { setFormData(DEFAULT_FORM); setIsAddModalOpen(true); }}
+              sx={{ py: 0.6, px: 2, fontWeight: 600, textTransform: 'none', borderRadius: 1.5, fontSize: '0.85rem', flexShrink: 0 }}
+            >
+              Add Entry
+            </Button>
+          </Box>
+        </Card>
+
+        {/* ── Table Card ──────────────────────────────────────────────────────── */}
+        <Card variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden', border: '1px solid', borderColor: 'divider', boxShadow: 'none' }}>
+          <TableContainer component={Paper} elevation={0} sx={{ borderRadius: 0, bgcolor: 'transparent' }}>
             <Table size="small">
-              <TableHead>
+              <TableHead sx={{ bgcolor: (theme) => theme.palette.mode === 'dark' ? 'rgba(30, 41, 59, 0.5)' : '#f1f5f9' }}>
                 <TableRow>
                   <SortableCell field="account_name">Account</SortableCell>
                   <SortableCell field="month">Month</SortableCell>
@@ -568,7 +570,7 @@ export default function SpendingAccountSummaryPage() {
                   <SortableCell field="current_credit" align="right">Credit Used</SortableCell>
                   <SortableCell field="balance_after_credit" align="right">Net Balance</SortableCell>
                   <SortableCell field="total_spent" align="right">Total Spent</SortableCell>
-                  <TableCell align="center">Actions</TableCell>
+                  <TableCell align="center" sx={{ fontWeight: 700, py: 1.25, fontSize: '0.78rem', textTransform: 'uppercase', letterSpacing: 0.5, color: 'text.secondary' }}>Actions</TableCell>
                 </TableRow>
               </TableHead>
               <TableBody>
@@ -579,27 +581,40 @@ export default function SpendingAccountSummaryPage() {
                     </TableCell>
                   </TableRow>
                 ) : (
-                  entries.map((entry) => (
-                    <TableRow key={entry.id} hover>
-                      <TableCell>{entry.accountName}</TableCell>
+                  entries.map((entry, idx) => (
+                    <TableRow
+                      key={entry.id}
+                      sx={{
+                        '& td': { py: 1 },
+                        bgcolor: idx % 2 === 0
+                          ? 'transparent'
+                          : (theme) => theme.palette.mode === 'dark' ? 'rgba(255,255,255,0.018)' : 'rgba(0,0,0,0.018)',
+                        '&:hover': { bgcolor: 'action.hover' },
+                      }}
+                    >
+                      <TableCell sx={{ fontWeight: 600 }}>{entry.accountName}</TableCell>
                       <TableCell>{MONTH_NAMES[entry.month - 1]}</TableCell>
                       <TableCell>{entry.year}</TableCell>
-                      <TableCell align="right">{formatCurrency(entry.startingBalance)}</TableCell>
-                      <TableCell align="right">{formatCurrency(entry.currentBalance)}</TableCell>
-                      <TableCell align="right">{formatCurrency(entry.currentCredit)}</TableCell>
-                      <TableCell align="right">{formatCurrency(entry.balanceAfterCredit)}</TableCell>
-                      <TableCell align="right">{formatCurrency(entry.totalSpent)}</TableCell>
-                      <TableCell align="center">
-                        <IconButton size="small" onClick={() => openEditModal(entry)} color="primary">
-                          <Edit fontSize="small" />
-                        </IconButton>
-                        <IconButton
-                          size="small"
-                          onClick={() => { setSelectedEntry(entry); setIsDeleteModalOpen(true); }}
-                          color="error"
-                        >
-                          <Trash2 fontSize="small" />
-                        </IconButton>
+                      <TableCell align="right" sx={{ fontWeight: 500 }}>{formatCurrency(entry.startingBalance)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 600, color: 'primary.main' }}>{formatCurrency(entry.currentBalance)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 500, color: 'warning.main' }}>{formatCurrency(entry.currentCredit)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 600 }}>{formatCurrency(entry.balanceAfterCredit)}</TableCell>
+                      <TableCell align="right" sx={{ fontWeight: 600, color: 'error.main' }}>{formatCurrency(entry.totalSpent)}</TableCell>
+                      <TableCell align="center" sx={{ whiteSpace: 'nowrap' }}>
+                        <Tooltip title="Edit">
+                          <IconButton size="small" onClick={() => openEditModal(entry)} color="secondary">
+                            <Edit fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
+                        <Tooltip title="Delete">
+                          <IconButton
+                            size="small"
+                            onClick={() => { setSelectedEntry(entry); setIsDeleteModalOpen(true); }}
+                            color="error"
+                          >
+                            <Trash2 fontSize="small" />
+                          </IconButton>
+                        </Tooltip>
                       </TableCell>
                     </TableRow>
                   ))
@@ -615,48 +630,47 @@ export default function SpendingAccountSummaryPage() {
             page={page}
             onPageChange={(_e, newPage) => setPage(newPage)}
             onRowsPerPageChange={(e) => { setRowsPerPage(parseInt(e.target.value, 10)); setPage(0); }}
+            sx={{ borderTop: '1px solid', borderColor: 'divider' }}
           />
         </Card>
 
         {/* ── Add Modal ────────────────────────────────────────────────────────── */}
-        <Dialog open={isAddModalOpen} onClose={() => setIsAddModalOpen(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Add New Entry</DialogTitle>
+        <Dialog open={isAddModalOpen} onClose={() => setIsAddModalOpen(false)} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>Add New Entry</DialogTitle>
           <DialogContent>
             <EntryFormFields formData={formData} accounts={accounts} onChange={setFormData} onAddAccountClick={() => setIsQuickAddAccountOpen(true)} />
           </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setIsAddModalOpen(false)}>Cancel</Button>
-            <Button onClick={handleAddEntry} variant="contained">Add Entry</Button>
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsAddModalOpen(false)} variant="text" color="inherit">Cancel</Button>
+            <Button onClick={handleAddEntry} variant="contained" color="primary">Add Entry</Button>
           </DialogActions>
         </Dialog>
 
         {/* ── Edit Modal ───────────────────────────────────────────────────────── */}
-        <Dialog open={isEditModalOpen} onClose={() => setIsEditModalOpen(false)} maxWidth="sm" fullWidth>
-          <DialogTitle>Edit Entry</DialogTitle>
+        <Dialog open={isEditModalOpen} onClose={() => setIsEditModalOpen(false)} maxWidth="sm" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>Edit Entry</DialogTitle>
           <DialogContent>
             <EntryFormFields formData={formData} accounts={accounts} onChange={setFormData} onAddAccountClick={() => setIsQuickAddAccountOpen(true)} />
           </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setIsEditModalOpen(false)}>Cancel</Button>
-            <Button onClick={handleEditEntry} variant="contained">Update Entry</Button>
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsEditModalOpen(false)} variant="text" color="inherit">Cancel</Button>
+            <Button onClick={handleEditEntry} variant="contained" color="primary">Update Entry</Button>
           </DialogActions>
         </Dialog>
 
         {/* ── Delete Modal ─────────────────────────────────────────────────────── */}
-        <Dialog open={isDeleteModalOpen} onClose={() => setIsDeleteModalOpen(false)}>
-          <DialogTitle>Delete Entry</DialogTitle>
+        <Dialog open={isDeleteModalOpen} onClose={() => setIsDeleteModalOpen(false)} maxWidth="xs" fullWidth PaperProps={{ sx: { borderRadius: 2, p: 1 } }}>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>Delete Entry</DialogTitle>
           <DialogContent>
-            <Typography>
+            <Typography variant="body2">
               Are you sure you want to delete this entry? This action cannot be undone.
             </Typography>
           </DialogContent>
-          <DialogActions>
-            <Button onClick={() => setIsDeleteModalOpen(false)}>Cancel</Button>
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsDeleteModalOpen(false)} variant="outlined" color="inherit">Cancel</Button>
             <Button onClick={handleDeleteEntry} variant="contained" color="error">Delete</Button>
           </DialogActions>
         </Dialog>
-
-
 
         {/* Inline Quick-Add Account Dialog */}
         <Dialog
@@ -664,8 +678,9 @@ export default function SpendingAccountSummaryPage() {
           onClose={() => setIsQuickAddAccountOpen(false)}
           maxWidth="xs"
           fullWidth
+          PaperProps={{ sx: { borderRadius: 2, p: 1 } }}
         >
-          <DialogTitle sx={{ fontWeight: 700 }}>Quick Add Account</DialogTitle>
+          <DialogTitle sx={{ fontWeight: 700, fontFamily: '"Space Grotesk", sans-serif' }}>Quick Add Account</DialogTitle>
           <DialogContent>
             <TextField
               fullWidth
@@ -684,11 +699,12 @@ export default function SpendingAccountSummaryPage() {
               sx={{ mt: 1 }}
             />
           </DialogContent>
-          <DialogActions sx={{ px: 3, pb: 3 }}>
-            <Button onClick={() => setIsQuickAddAccountOpen(false)}>Cancel</Button>
+          <DialogActions sx={{ p: 2 }}>
+            <Button onClick={() => setIsQuickAddAccountOpen(false)} variant="text" color="inherit">Cancel</Button>
             <Button
               onClick={handleQuickAddAccount}
               variant="contained"
+              color="primary"
               disabled={quickAddLoading || !quickAddAccountName.trim()}
             >
               Create

--- a/keys-personal-assist-ui/src/utils/formatters.ts
+++ b/keys-personal-assist-ui/src/utils/formatters.ts
@@ -9,6 +9,24 @@ export const formatCurrency = (value: number): string => {
   return INDIAN_RUPEE_FORMAT.format(value);
 };
 
+export const formatCompactRupees = (value: number): string => {
+  if (value === 0) return '₹0.00';
+  const isNegative = value < 0;
+  const absVal = Math.abs(value);
+  let result = '';
+
+  if (absVal >= 10000000) {
+    result = `₹${(absVal / 10000000).toFixed(2)} Cr`;
+  } else if (absVal >= 100000) {
+    result = `₹${(absVal / 100000).toFixed(2)}L`;
+  } else {
+    result = formatCurrency(absVal);
+    return isNegative ? `-${result}` : result;
+  }
+  
+  return isNegative ? `-${result}` : result;
+};
+
 export const getMonthName = (monthIndex: number): string => {
   const date = new Date();
   date.setMonth(monthIndex);


### PR DESCRIPTION
This pull request standardizes the UI layout, component structures, and navigation paths across all key Finance module views to align them with the design system established in the Assets manager redesign.

### Key Changes

1. **Navigation Structure**
   - Extrapolated the nested "Account Balances" and "Savings Envelopes" from the "Dashboard" sub-menu to flat, top-level items under "Finance" in `AppShell.tsx`.
   - Renamed "Account Balances" to "Spending Accounts" for clearer intent.

2. **UI & Styling Alignments**
   - Standardized layout structures, container wrappers, page headings, captions, and toolbars in `SpendingAccountSummaryPage.tsx`, `SavingsFundSegregatorPage.tsx`, and `MonthlyPlannerPage.tsx`.
   - Applied consistent dark mode compatibility, custom rounded-corner dialogs, typography, and button orders across all dialog views.

3. **Metrics Card Improvements**
   - Replaced flex-based metric summary blocks with responsive `<Grid container>` modules.
   - Fixed divider alignment bugs on mobile wrapping by setting responsive, explicit `borderRightColor` and `borderBottomColor` properties matching the theme's `divider` token.

4. **Click-to-Edit Salary**
   - Implemented interactive click-to-edit typography for Current Salary on the Monthly Budget page (`MonthlyPlannerPage.tsx`), which toggles to an input field and saves changes on blur/Enter.

5. **Shared Formatters**
   - Refactored `formatCompactRupees` out of `AssetsTab.tsx` and moved it into the shared `formatters.ts` utility file.
